### PR TITLE
Refactor dependency analysis for multiple instance options.

### DIFF
--- a/dependency.go
+++ b/dependency.go
@@ -87,8 +87,10 @@ func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance s
 				if len(targetSplit)>1 {
 					if strings.Contains(targetSplit[1], "%TARGET") {
 						newTarget += ":"+strings.Replace(targetSplit[1], "%TARGET", target.Name, -1)
-					} else {
+					} else if len(targetInstances)>1 {
 						newTarget += ":"+target.Name+"_"+targetSplit[1]
+					} else {
+						newTarget += ":"+targetSplit[1]
 					}
 				}
 				newTargets = append(newTargets, newTarget)

--- a/dependency.go
+++ b/dependency.go
@@ -71,10 +71,10 @@ func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance s
 		if targetNode, ok := node.Dependencies[targetNodeName]; ok {
 			targetInstances = []*Instance{}
 
-			if targetInstanceName=="%all" {
+			if targetInstanceName=="%ALL" {
 				// in this case we have a meta request to link to all active instances of a target
 				targetInstances = targetNode.GetInstances(true)
-			} else if targetInstanceName=="%random" {
+			} else if targetInstanceName=="%RANDOM" {
 				if randomTarget := targetNode.GetRandomInstance(true); randomTarget!=nil {
 					targetInstances = []*Instance{ randomTarget }
 				}
@@ -85,8 +85,8 @@ func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance s
 			for _, target := range targetInstances {
 				newTarget := target.GetContainerName()
 				if len(targetSplit)>1 {
-					if strings.Contains(targetSplit[1], "%target") {
-						newTarget += ":"+strings.Replace(targetSplit[1], "%target", target.Name, -1)
+					if strings.Contains(targetSplit[1], "%TARGET") {
+						newTarget += ":"+strings.Replace(targetSplit[1], "%TARGET", target.Name, -1)
 					} else {
 						newTarget += ":"+target.Name+"_"+targetSplit[1]
 					}

--- a/dependency.go
+++ b/dependency.go
@@ -4,18 +4,22 @@ import (
 	"strings"
 )
 
+/**
+ * Match any Config and HostConfig identifiers to any nodes in the nodes array
+ * and add them to the Node's map of dependencies
+ */
 func (node *Node) SetDependencies(nodes Nodes) {
 
 	dependencies := []string{}
 
 	if node.HostConfig.Links!=nil {
 		for _, name := range node.HostConfig.Links {
-			dependencies = append(dependencies, strings.SplitN(name, ":", 2)[0])
+			dependencies = append(dependencies, DependencyBase(name))
 		}
 	}
 	if node.HostConfig.VolumesFrom!=nil {
 		for _, name := range node.HostConfig.VolumesFrom {
-			dependencies = append(dependencies, strings.SplitN(name, ":", 2)[0])
+			dependencies = append(dependencies, DependencyBase(name))
 		}
 	}
 
@@ -25,4 +29,83 @@ func (node *Node) SetDependencies(nodes Nodes) {
 		}
 	}
 
+}
+
+/**
+ * Interpret the instance dependency format, for a node instance identifier
+ *
+ * This format interpreter allows nodes to use node instance identifiers in their
+ * Docker settings for values such as --links, and --volumes-from.  the format
+ * allows a simple synax from one node, that defines a particular target instance.
+ *
+ * This gets used by the node processors various times to convert syntax into
+ * container name
+ *
+ * @param targets []string a slice of strings of the either syntax "instance" or "instance:destination", as used
+ *    in the docker client VolumesFrom, Links etc fields
+ *
+ * @note subsitutions are made if the string target can be matched to a node in the Dependencies map,
+ *   with the following syntax allowed to target specific instances:
+ *     {node}                   => fallback instance of that node will be matched
+ *     {node}->{instance}       => {instance} or the fallback of that node will be matched
+ *     {node}->all              => all instances of that node will be matched
+ *     {node}->random           => a random instance of that node will be matched (fallback is ignored)
+ *
+ * @returns Container Name as a string, and success boolean
+ */
+func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance string) []string {
+	newTargets := []string{}
+	var targetInstances []*Instance
+
+	for _, target := range targets {
+		targetSplit := strings.SplitN(target, ":", 2)
+		targetNodeName := targetSplit[0]
+		targetInstanceName := ""
+
+		if strings.Contains(targetNodeName, "->") {
+			subSplit := strings.SplitN(targetNodeName, "->", 2)
+			targetNodeName = subSplit[0]
+			targetInstanceName = subSplit[1]
+		}
+
+		if targetNode, ok := node.Dependencies[targetNodeName]; ok {
+			targetInstances = []*Instance{}
+
+			if targetInstanceName=="%all" {
+				// in this case we have a meta request to link to all active instances of a target
+				targetInstances = targetNode.GetInstances(true)
+			} else if targetInstanceName=="%random" {
+				if randomTarget := targetNode.GetRandomInstance(true); randomTarget!=nil {
+					targetInstances = []*Instance{ randomTarget }
+				}
+			} else {
+				targetInstances = targetNode.FilterInstances([]string{targetInstanceName, fallbackInstance}, true)
+			}
+
+			for _, target := range targetInstances {
+				newTarget := target.GetContainerName()
+				if len(targetSplit)>1 {
+					if strings.Contains(targetSplit[1], "%target") {
+						newTarget += ":"+strings.Replace(targetSplit[1], "%target", target.Name, -1)
+					} else {
+						newTarget += ":"+target.Name+"_"+targetSplit[1]
+					}
+				}
+				newTargets = append(newTargets, newTarget)
+			}
+		}
+	}
+
+	return newTargets
+}
+
+
+func DependencyBase(dependency string) string {
+	if strings.Contains(dependency, "->") {
+		return strings.SplitN(dependency, "->", 2)[0]
+	} else if strings.Contains(dependency, ":") {
+		return strings.SplitN(dependency, ":", 2)[0]
+	} else {
+		return dependency
+	}
 }

--- a/operation_init_default.go
+++ b/operation_init_default.go
@@ -88,7 +88,7 @@ www:
     Hostname: "%PROJECT_%INSTANCE"                  # Token : project name (can be set in conf.yml)
     Domainname: "%DOMAIN"                           # Token : can be set in conf.yml:Tokens
     Env:
-      - DNSDOCK_ALIAS="%PROJECT.%CONTAINER_DOMAIN"  # If you are using DNSDOCK, this will create a DNS Entry.
+      - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN"  # If you are using DNSDOCK, this will create a DNS Entry.
 
     ExposedPorts:
       80/tcp: {}

--- a/operation_init_default.go
+++ b/operation_init_default.go
@@ -9,15 +9,15 @@ func (operation *Operation_Init) Init_Default_Files() map[string]string {
 Paths:  # a map of paths and path overrides (see conf.go)
   test: "/test/path"
 
-Tokens: 1# a map of string tokens, used for token replacement in the nodes.yml
-  CONTAINER_DOMAIN: "local.wunder.io"
-  TEST: TESTTOKENVALUE
+Tokens: # a map of string tokens, used for token replacement in the nodes.yml
+  CONTAINER_DOMAIN: "docker"
 
 Settings:
-  UseEnvVariablesAsTokens: "yes"
+  UseEnvVariablesAsTokens: "yes"   # include all of the user's ENV variables as possible tokens
 
 Docker:  # Override Docker configuration
-  #Host: "tcp://10.0.42.1"`,
+#  Host: "tcp://10.0.42.1"         # point to a remote docker server
+`,
 
 		".coach/nodes.yml":  `
 # Files volume container
@@ -57,7 +57,7 @@ db:
 
   Host:
     VolumesFrom:
-      - files                     # I am not sure if this is needed
+      - files                              # I am not sure if this is needed
 
 # FPM service
 fpm:
@@ -85,10 +85,10 @@ www:
     Image: jamesnesbitt/wunder-nginx
     RestartPolicy: on-failure
 
-    Hostname: #PROJECT#                 # Token : project name (can be set in conf.yml)
-    Domainname: #DOMAIN#                # Token : can be set in conf.yml:Tokens
+    Hostname: "%PROJECT_%INSTANCE"                  # Token : project name (can be set in conf.yml)
+    Domainname: "%DOMAIN"                           # Token : can be set in conf.yml:Tokens
     Env:
-      - DNSDOCK_ALIAS=#PROJECT#.#CONTAINER_DOMAIN#  # If you are using DNSDOCK, this will create a DNS Entry.
+      - DNSDOCK_ALIAS="%PROJECT.%CONTAINER_DOMAIN"  # If you are using DNSDOCK, this will create a DNS Entry.
 
     ExposedPorts:
       80/tcp: {}
@@ -109,7 +109,7 @@ www:
 `,
 
 		".coach/secrets/secrets.yml":  `# SECRET TOKENS THAT CAN BE KEPT OUT OF GIT
-SECRET: VALUE
+#SECRET: VALUE
 `,
 
 		"app/README.md":  `


### PR DESCRIPTION
This patch transforms how dependencies for nodes are determined, and how those dependencies are transformed into container names for Config and HostConfig definitions.

For example, if you link a scaled node to a single now, then the single node instance is the target.  If two scaled nodes are linked, then coach tries to match the instances (1=1, 2=2, 3=3).  If a single is linked to a scaled, then you should define which item you want, or use some of the new tokens.

Here are some example patterns:

If you have the node: nginx (single) and fpm (scaled 3)

nginx:
  Links:
    - "fpm->%all:fpm.%TARGET.app"   # links all of the fpm instances to nginx (and names them)

nginx:
 Links:
    - "fpm->1:fpm.app"  # links only the first fpm instance to nginx 

nginx:
  Links:
    - "fpm->%RANDOM:fpm.app"  # links a random fpm instance to the nginx container
