### PR TITLE
User and Git Inits [ongoing]

### DIFF
--- a/coach.go
+++ b/coach.go
@@ -36,6 +36,7 @@ func main() {
 	log := GetLog(os.Stdout, verbosity)
 
 	log.DebugObject(LOG_SEVERITY_DEBUG, "Global Flags:", globalFlags)
+	log.DebugObject(LOG_SEVERITY_MESSAGE, "Operation Flags:", operationFlags)
 	log.DebugObject(LOG_SEVERITY_DEBUG, "Initial Targets:", targets)
 
 	/**
@@ -97,7 +98,8 @@ func parseGlobalFlags(flags []string) (operation string, targets []string, globa
 	targets = []string{}
 
 	global := true // start of assuming everything is a global arg
-	for index, arg := range flags[1:] {
+	for index:=1; index<len(flags); index++ {
+		arg := flags[index]
 
 		switch(arg) {
 			case "-v":
@@ -113,7 +115,6 @@ func parseGlobalFlags(flags []string) (operation string, targets []string, globa
 			case "--staaap":
 				globalFlags["verbosity"] = "staaap"
 				fallthrough
-
 
 			case "--all": // this is default anyway
 				targets = append(targets, "$all")

--- a/coach.go
+++ b/coach.go
@@ -36,7 +36,6 @@ func main() {
 	log := GetLog(os.Stdout, verbosity)
 
 	log.DebugObject(LOG_SEVERITY_DEBUG, "Global Flags:", globalFlags)
-	log.DebugObject(LOG_SEVERITY_MESSAGE, "Operation Flags:", operationFlags)
 	log.DebugObject(LOG_SEVERITY_DEBUG, "Initial Targets:", targets)
 
 	/**

--- a/conf_secretsyaml.go
+++ b/conf_secretsyaml.go
@@ -7,25 +7,23 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const confsource_secrettokenyaml_filename string = "secrets.yml"
-
 /**
  * Get more conf tokens from the secrets file, which is usually at .coach/secrets/secrets.yaml
  */
-func (conf *Conf) from_SecretsYaml(log Log) {
+func (conf *Conf) from_SecretsYaml(log Log, confPathKey string) bool {
 	log.Debug(LOG_SEVERITY_DEBUG_LOTS,"Updating Conf from secrets")
 
-	if confPath, ok := conf.Path("secrets"); ok {
+	if confPath, ok := conf.Path(confPathKey); ok {
 		// get the path to where the config file should be
-		confPath = path.Join(confPath, confsource_secrettokenyaml_filename)
+		confPath = path.Join(confPath, "secrets.yml")
 
-		log.Debug(LOG_SEVERITY_DEBUG_WOAH,"Project secrets file:"+confPath)
+		log.Debug(LOG_SEVERITY_DEBUG_WOAH,"Secrets file:"+confPath)
 
 		// read the config file
 		yamlFile, err := ioutil.ReadFile(confPath)
 		if err!=nil {
-			log.Error("Could not read the YAML secrets file: "+err.Error())
-			return
+			log.Debug(LOG_SEVERITY_DEBUG_LOTS,"Could not read the YAML file ["+confPath+"]: "+err.Error())
+			return false
 		}
 
 		// replace tokens in the yamlFile
@@ -35,17 +33,20 @@ func (conf *Conf) from_SecretsYaml(log Log) {
 		// parse the config file contents as a ConfSource_secrettokensyaml object
 		source := new(Conf_SecretsYaml)
 		if err := yaml.Unmarshal([]byte(yamlFile), source); err!=nil {
-			log.Error("YAML marshalling of the YAML secrets file failed: "+err.Error())
-			return
+			log.Warning("YAML marshalling of the YAML conf file failed ["+confPath+"]: "+err.Error())
+			return false
 		}
 		log.DebugObject(LOG_SEVERITY_DEBUG_STAAAP,"secrets source:", *source)
 
 		conf.Merge( source.toConf() )
 
+		return true
+
 	} else {
 		log.Debug(LOG_SEVERITY_DEBUG_LOTS,"YAML secrets file not found, no project coach folder:"+confPath)
 	}
 
+	return false
 }
 
 /**

--- a/instance.go
+++ b/instance.go
@@ -8,7 +8,6 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-
 func (node *Node) ConfigureInstances_Single() bool {
 	node.InstanceType = "single"
 	node.AddInstance("single", true)

--- a/node_fromyaml.go
+++ b/node_fromyaml.go
@@ -25,7 +25,7 @@ func (nodes *Nodes) from_Yaml(log Log, conf *Conf) {
 		// read the config file
 		yamlFile, err := ioutil.ReadFile(nodesPath)
 		if err!=nil {
-			log.Error("Could not read the YAML file: "+err.Error())
+			log.Warning("Could not read the YAML file: "+err.Error())
 			return
 		}
 

--- a/operation_init.go
+++ b/operation_init.go
@@ -3,42 +3,58 @@ package main
 import (
 	"os"
 	"path"
+	"strings"
 )
 
 type Operation_Init struct {
 	conf *Conf
 	log Log
 
-	root string
-	variant string
+	root string							// Path to root
+	variant string					// which method to use to initialize
+	handlerFlags []string 	// flags to pass to the variant handler
+
 	force bool
 
-	Targets []string
+	Targets []string				// often not used, but perhaps it might be useful to define what nodes to create in some scenarios
 }
+
 func (operation *Operation_Init) Flags(flags []string) {
 
+	operation.root, _ = os.Getwd()
 	operation.variant = "default"
-	operation.force = false
 
 	remainingFlags := []string{}
-	for index, flag := range flags {
-		switch flag {
-			case "-f":
-				fallthrough
-			case "--force":
-				operation.force = true
 
-			default:
-				remainingFlags = flags[index:]
-				break;
+  flagLoop:
+		for index:=0; index<len(flags); index++ {
+			flag:= flags[index]
+
+			switch flag {
+				case "-d":
+					fallthrough
+				case "--in-directory":
+					if !strings.HasPrefix(flags[index+1], "-") {
+						operation.root = flags[index+1]
+						index++
+					}
+				case "-f":
+					fallthrough
+				case "--force":
+					operation.force = true
+
+				default:
+					remainingFlags = flags[index:]
+					break flagLoop
+			}
 		}
-	}
 
 	if variant := remainingFlags[0]; variant!="" {
 		operation.variant = variant
+		remainingFlags = remainingFlags[1:]
 	}
 
-	operation.root, _ = os.Getwd()
+	operation.handlerFlags = remainingFlags
 }
 func (operation *Operation_Init) Run() {
 	var err error
@@ -72,13 +88,19 @@ func (operation *Operation_Init) Run() {
 
 	operation.log.Message("Preparing INIT operation in path : "+targetPath)
 
-	// get a list of files to create
-	files := map[string]string{}
+	// a list of files to create, optionally passed as a return by the init methods
+	var files map[string]string
+
+	operation.log = operation.log.ChildLog(strings.ToUpper(operation.variant))
 	switch operation.variant {
+		case "user":
+			_, files = operation.Init_User_Run(operation.handlerFlags)
+		case "git":
+			_, files = operation.Init_Git_Run(operation.handlerFlags)
 		case "default":
 			fallthrough
 		default:
-			files = operation.Init_Default_Files()
+			_, files = operation.Init_Default_Run(operation.handlerFlags)
 	}
 
 	for filePath, fileContents := range files {
@@ -86,6 +108,8 @@ func (operation *Operation_Init) Run() {
 		operation.MakeFile(filePath, fileContents)
 	}
 }
+
+
 func (operation *Operation_Init) MakeFile(filePath string, fileContents string) bool {
 
 	initPath := operation.root

--- a/operation_init_default.go
+++ b/operation_init_default.go
@@ -1,7 +1,7 @@
 package main
 
-func (operation *Operation_Init) Init_Default_Files() map[string]string {
-	return map[string]string{
+func (operation *Operation_Init) Init_Default_Run(flags []string) (bool, map[string]string) {
+	return true, map[string]string{
 
 		".coach/conf.yml":  `Project: Coach
 #Author: Used for docker commits

--- a/operation_init_git.go
+++ b/operation_init_git.go
@@ -1,15 +1,33 @@
 package main
 
 import (
-// 	"os"
-// 	"io"
-//
-// 	"github.com/libgit2/git2go"
+ 	git "github.com/libgit2/git2go"
 )
 
 func (operation *Operation_Init) Init_Git_Run(flags []string) (bool, map[string]string) {
 
+	if len(flags)==0 {
+		operation.log.Error("You have not provided a git target $/> coach init git https://github.com/aleksijohansson/docker-drupal-coach")
+		return false, map[string]string{}
+	}
 
+	target := flags[0]
+
+	options := git.CloneOptions{
+		Bare: false,
+	}
+
+	if len(flags)>1 {
+		options.CheckoutBranch = flags[1]
+	}
+
+	operation.log.Message("Clone remote repository to local project folder ["+target+"]")
+	_, err := git.Clone(target, operation.root, &options)
+	if err!=nil {
+		operation.log.Error("Failed to clone the remote repository ["+target+"] => "+err.Error())
+	} else {
+		operation.log.Message("Clone remote repository to local project folder")
+	}
 
 	return true, map[string]string{
 		".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM GIT`,

--- a/operation_init_git.go
+++ b/operation_init_git.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+// 	"os"
+// 	"io"
+//
+// 	"github.com/libgit2/git2go"
+)
+
+func (operation *Operation_Init) Init_Git_Run(flags []string) (bool, map[string]string) {
+
+
+
+	return true, map[string]string{
+		".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM GIT`,
+	}
+}

--- a/operation_init_git.go
+++ b/operation_init_git.go
@@ -26,7 +26,7 @@ func (operation *Operation_Init) Init_Git_Run(flags []string) (bool, map[string]
 	if err!=nil {
 		operation.log.Error("Failed to clone the remote repository ["+target+"] => "+err.Error())
 	} else {
-		operation.log.Message("Clone remote repository to local project folder")
+		operation.log.Message("Cloned remote repository to local project folder")
 	}
 
 	return true, map[string]string{

--- a/operation_init_user.go
+++ b/operation_init_user.go
@@ -9,6 +9,11 @@ import (
 func (operation *Operation_Init) Init_User_Run(flags []string) (bool, map[string]string) {
 operation.log.DebugObject( LOG_SEVERITY_MESSAGE, "FLAGS:", flags)
 
+	if len(flags)==0 {
+		operation.log.Error("You have not provided a template name  $/> coach init user {template}")
+		return false, map[string]string{}
+	}
+
 	template := flags[0]
 	flags = flags[1:]
 

--- a/operation_init_user.go
+++ b/operation_init_user.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"io"
+	"path"
+)
+
+func (operation *Operation_Init) Init_User_Run(flags []string) (bool, map[string]string) {
+operation.log.DebugObject( LOG_SEVERITY_MESSAGE, "FLAGS:", flags)
+
+	template := flags[0]
+	flags = flags[1:]
+
+	templatePath, ok := operation.conf.Path("usertemplates")
+	if !ok {
+		operation.log.Error("COACH has no directive for a user template path")
+		return false, map[string]string{}
+	}
+	targetPath := path.Join(templatePath , template )
+
+	if _, err := os.Stat( targetPath ); err!=nil {
+		operation.log.Error("Invalid template path suggested for new project init : ["+template+"] expected path ["+targetPath+"] => "+err.Error())
+		return false, map[string]string{}
+	}
+
+	operation.log.Message("Copying new project init from template : ["+template+"] path ["+targetPath+"]")
+	if err := CopyDir(targetPath, operation.root); err!=nil {
+		operation.log.Error("Falied copying new project init from template : ["+template+"] expected path ["+targetPath+"] => "+err.Error())
+		return false, map[string]string{}
+	}
+
+	return true, map[string]string{
+		".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM A User Template`,
+	}
+}
+
+func CopyFile(source string, dest string) (err error) {
+		sourcefile, err := os.Open(source)
+		if err != nil {
+				return err
+		}
+
+		defer sourcefile.Close()
+
+		destfile, err := os.Create(dest)
+		if err != nil {
+				return err
+		}
+
+		defer destfile.Close()
+
+		_, err = io.Copy(destfile, sourcefile)
+		if err == nil {
+				sourceinfo, err := os.Stat(source)
+				if err != nil {
+						err = os.Chmod(dest, sourceinfo.Mode())
+				}
+
+		}
+
+		return
+}
+
+func CopyDir(source string, dest string) (err error) {
+
+		// get properties of source dir
+		sourceinfo, err := os.Stat(source)
+		if err != nil {
+				return err
+		}
+
+		// create dest dir
+
+		err = os.MkdirAll(dest, sourceinfo.Mode())
+		if err != nil {
+				return err
+		}
+
+		directory, _ := os.Open(source)
+
+		objects, err := directory.Readdir(-1)
+
+		for _, obj := range objects {
+
+				sourcefilepointer := source + "/" + obj.Name()
+
+				destinationfilepointer := dest + "/" + obj.Name()
+
+
+				if obj.IsDir() {
+						// create sub-directories - recursively
+						err = CopyDir(sourcefilepointer, destinationfilepointer)
+						if err != nil {
+// 								fmt.Println(err)
+						}
+				} else {
+						// perform copy
+						err = CopyFile(sourcefilepointer, destinationfilepointer)
+						if err != nil {
+// 								fmt.Println(err)
+						}
+				}
+
+		}
+		return
+}


### PR DESCRIPTION
This ongoing patch adds new user and git init options
# User templates

$/> coach init user {template}

will copy the contents of ~/.coach/templates/{template} into the current path
# Git templates

$/> coach init git https://github.com/aleksijohansson/docker-drupal-coach

will git clone out the suggested git repo for the template

@NOTE that the user template concept required refactor of the conf and secrets implementation to make them reusable.  This actually resulted in code reduction.
