### PR TITLE
make init git method more verbose, connected os.Stdin for passphrases

### DIFF
--- a/operation_init_git.go
+++ b/operation_init_git.go
@@ -15,19 +15,23 @@ func (operation *Operation_Init) Init_Git_Run(flags []string) (bool, map[string]
 	url := flags[0]
 	path := operation.root
 
-	cmd := exec.Command("git", "clone", url, path)
+	cmd := exec.Command("git", "clone", "--progress", url, path)
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = operation.log
+	cmd.Stderr = operation.log
 
 	operation.log.Message("Clone remote repository to local project folder ["+url+"]")
 	err := cmd.Run()
+
 	if err!=nil {
 		operation.log.Error("Failed to clone the remote repository ["+url+"] => "+err.Error())
+		return false, map[string]string{}
 	} else {
+
 		operation.log.Message("Cloned remote repository to local project folder")
+		return true, map[string]string{
+			".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM GIT`,
+		}
 	}
 
-	return true, map[string]string{
-		".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM GIT`,
-	}
 }

--- a/operation_init_git.go
+++ b/operation_init_git.go
@@ -20,14 +20,21 @@ func (operation *Operation_Init) Init_Git_Run(flags []string) (bool, map[string]
 	cmd.Stdout = operation.log
 	cmd.Stderr = operation.log
 
+
+	err := cmd.Start()
+
+	if err!=nil {
+		operation.log.Error("Failed to clone the remote repository ["+url+"] => "+err.Error())
+		return false, map[string]string{}
+	}
+
 	operation.log.Message("Clone remote repository to local project folder ["+url+"]")
-	err := cmd.Run()
+	err = cmd.Wait()
 
 	if err!=nil {
 		operation.log.Error("Failed to clone the remote repository ["+url+"] => "+err.Error())
 		return false, map[string]string{}
 	} else {
-
 		operation.log.Message("Cloned remote repository to local project folder")
 		return true, map[string]string{
 			".coach/CREATEDFROM.md":  `THIS PROJECT WAS CREATED FROM GIT`,


### PR DESCRIPTION
git clone stdout&stderr are connected (more verbose)
stdin is connected in case you need to enter a passphrase
git clone has --progress flag added

Mainly this patch is a response to https://github.com/james-nesbitt/coach/issues/8
