### PR TITLE
Fix create operation for images with tags

### DIFF
--- a/operation_build.go
+++ b/operation_build.go
@@ -3,7 +3,6 @@ package main
 import (
 	"path"
 	"os"
-	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -54,9 +53,12 @@ func (node *Node) Build(force bool) bool {
 		buildPath = path.Join(buildPath, node.BuildPath)
 
 		image := node.GetImageName()
+		if tag := node.GetImageTag(); tag!="" {
+			image +=":"+tag
+		}
 
 		options := docker.BuildImageOptions{
-			Name: strings.ToLower(image),
+			Name: image,
 			ContextDir: buildPath,
 			RmTmpContainer: true,
 			OutputStream: os.Stdout,

--- a/operation_create.go
+++ b/operation_create.go
@@ -72,7 +72,11 @@ func (instance *Instance) Create(overrideCmd []string, force bool) bool {
 		Config := instance.Config
 		HostConfig := instance.HostConfig
 
-		Config.Image = node.GetImageName()
+		image := node.GetImageName()
+		if tag := node.GetImageTag(); tag!="" && tag!="latest" {
+			image +=":"+tag
+		}
+		node.Config.Image = image
 
 		if len(overrideCmd)>0 {
 			Config.Cmd = overrideCmd

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -47,6 +47,9 @@ func (node *Node) Destroy(force bool) bool {
 
 		// Get the image name
 		image := node.GetImageName()
+		if tag := node.GetImageTag(); tag!="" && tag!="latest" {
+			image +=":"+tag
+		}
 
 		options := docker.RemoveImageOptions{
 			Force: force,

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -36,13 +36,19 @@ func (node *Node) Pull(registry string) bool {
 	if node.Do("pull") {
 
 		image := node.GetImageName()
-		tag := node.GetImageTag()
+		if tag := node.GetImageTag(); tag!="" && tag!="latest" {
+			image +=":"+tag
+		}
 
 		options := docker.PullImageOptions {
 			Repository: image,
-			Tag: tag,
 			OutputStream: os.Stdout,
 			RawJSONStream:false,
+		}
+
+		tag:=node.GetImageTag();
+		if tag!="" {
+			options.Tag = tag
 		}
 
 		var auth docker.AuthConfiguration


### PR DESCRIPTION
Issue: https://github.com/james-nesbitt/coach/issues/9

The coach image identification process was modified to allow some centralized image name generation, but the refactored operations did not take into account intentional tags in image names.  This patch fixes that:
1. create: if you have a Config: Image: {image}:{tag}  it should work now
2. pull: pays attention to image tags
3. destroy: pays attention to imate tags
4. if you add a Config: Image: {image}:{tag} to a node that has a buildpath, the config value is used, with it's tag.
