### PR TITLE
fixed bad image override in create operation

### DIFF
--- a/operation_create.go
+++ b/operation_create.go
@@ -76,7 +76,7 @@ func (instance *Instance) Create(overrideCmd []string, force bool) bool {
 		if tag := node.GetImageTag(); tag!="" && tag!="latest" {
 			image +=":"+tag
 		}
-		node.Config.Image = image
+		Config.Image = image
 
 		if len(overrideCmd)>0 {
 			Config.Cmd = overrideCmd


### PR DESCRIPTION
The Existing create operation has some code which determines what image to use during create.  This code is needed as the image name could come from a nodes configuration, or could be determined dymanically if the image is a build.

The code had a mistake in that it overrode the wrong variable (bad copy and paste.)

This was discovered while working on https://github.com/james-nesbitt/coach/issues/9
