### PR TITLE
Implemented Run operation

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -20,6 +20,9 @@ func GetOperation(name string, nodes Nodes, targets []string, client *docker.Cli
 		case "destroy":
 			return Operation(&Operation_Destroy{log:log.ChildLog("DESTROY"), Nodes:nodes, Targets:targets})
 
+		case "run":
+			return Operation(&Operation_Run{log:log.ChildLog("RUN"), Nodes:nodes, Targets:targets})
+
 		case "create":
 			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), Nodes:nodes, Targets:targets})
 		case "remove":

--- a/operation_create.go
+++ b/operation_create.go
@@ -42,15 +42,19 @@ func (nodes *Nodes) Create(targets []string, onlyActive bool, force bool) {
 }
 
 func (node *Node) Create(filters []string, onlyActive bool, force bool) {
-	var instances []*Instance
+	if node.Do("create") {
 
-	if len(filters)==0 {
-		instances = node.GetInstances(onlyActive)
-	} else {
-		instances = node.FilterInstances(filters, onlyActive)
-	}
-	for _, instance := range instances {
-		instance.Create([]string{}, force)
+		var instances []*Instance
+
+		if len(filters)==0 {
+			instances = node.GetInstances(onlyActive)
+		} else {
+			instances = node.FilterInstances(filters, onlyActive)
+		}
+		for _, instance := range instances {
+			instance.Create([]string{}, force)
+		}
+
 	}
 }
 
@@ -60,61 +64,55 @@ func (node *Node) Create(filters []string, onlyActive bool, force bool) {
 func (instance *Instance) Create(overrideCmd []string, force bool) bool {
 	node := instance.Node
 
-	if node.Do("create") {
+	/**
+		* Transform node data, into a format that can be used
+		* for the actual Docker call.  This involves transforming
+		* the node keys into docker container ids, for things like
+		* the name, Links, VolumesFrom etc
+		*/
+	name := instance.GetContainerName()
+	Config := instance.Config
+	HostConfig := instance.HostConfig
+
+	image := node.GetImageName()
+	if tag := node.GetImageTag(); tag!="" && tag!="latest" {
+		image +=":"+tag
+	}
+	node.Config.Image = image
+
+	if len(overrideCmd)>0 {
+		Config.Cmd = overrideCmd
+	}
+
+	// ask the docker client to create a container for this instance
+	options := docker.CreateContainerOptions{
+		Name:name,
+		Config:&Config,
+		HostConfig:&HostConfig,
+	}
+
+	container, err := instance.Node.client.CreateContainer( options )
+
+	if (err!=nil) {
 
 		/**
-			* Transform node data, into a format that can be used
-			* for the actual Docker call.  This involves transforming
-			* the node keys into docker container ids, for things like
-			* the name, Links, VolumesFrom etc
+			* There is a weird bug with the library, where sometimes it
+			* reports a missing image error, and yet it still creates the
+			* container.  It is not clear if this failure occurs in the
+			* remote API, or in the dockerclient library.
 			*/
-		name := instance.GetContainerName()
-		Config := instance.Config
-		HostConfig := instance.HostConfig
-
-		image := node.GetImageName()
-		if tag := node.GetImageTag(); tag!="" && tag!="latest" {
-			image +=":"+tag
-		}
-		node.Config.Image = image
-
-		if len(overrideCmd)>0 {
-			Config.Cmd = overrideCmd
-		}
-
-		// ask the docker client to create a container for this instance
-		options := docker.CreateContainerOptions{
-			Name:name,
-			Config:&Config,
-			HostConfig:&HostConfig,
-		}
-
-		container, err := instance.Node.client.CreateContainer( options )
-
-		if (err!=nil) {
-
-			/**
-			 * There is a weird bug with the library, where sometimes it
-			 * reports a missing image error, and yet it still creates the
-			 * container.  It is not clear if this failure occurs in the
-			 * remote API, or in the dockerclient library.
-			 */
-			if err.Error()=="no such image" {
-				if container, ok := instance.GetContainer(false); ok {
-					instance.Node.log.Message("CREATED INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] => "+container.ID)
-					instance.Node.log.Warning("Docker created the container, but reported an error due to a 'missing image'")
-					return true
-				}
+		if err.Error()=="no such image" {
+			if container, ok := instance.GetContainer(false); ok {
+				instance.Node.log.Message("CREATED INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] => "+container.ID)
+				instance.Node.log.Warning("Docker created the container, but reported an error due to a 'missing image'")
+				return true
 			}
-
-			instance.Node.log.Error("FAILED TO CREATE INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] =>"+err.Error())
-			return false
-		} else {
-			instance.Node.log.Message("CREATED INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] => "+container.ID)
-			return true
 		}
 
+		instance.Node.log.Error("FAILED TO CREATE INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] =>"+err.Error())
+		return false
+	} else {
+		instance.Node.log.Message("CREATED INSTANCE CONTAINER ["+name+" FROM "+Config.Image+"] => "+container.ID)
+		return true
 	}
-	return false
 }
-

--- a/operation_run.go
+++ b/operation_run.go
@@ -51,9 +51,12 @@ func (node *Node) Run(cmd []string) bool {
 				instance.Attach()
 				return true
 			} else {
+				node.log.Error("Could not start RUN container")
 				return false
 			}
 
+		} else {
+			node.log.Error("Could not create RUN container")
 		}
 
 	}


### PR DESCRIPTION
Implemented the run operation as a core operation, which required a small change in the create operation.

The create change looks like a big diff, but all it is really is moving the permissions check from the instance method to the node method.  This change is required because run containers need to be created, but may not be containers that are considered creatable (such as command containers.)
