### PR TITLE
made run operation allow for persistant containers

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -18,13 +18,9 @@ func (node *Node) ConfigureInstances_Temporary() bool {
 	return true
 }
 func (node *Node) ConfigureInstances_Fixed(instances []string) bool {
-	if node.Do("start") {
-		node.InstanceType = "fixed"
-		node.AddInstances(instances, true)
-		return true
-	} else {
-		return false
-	}
+	node.InstanceType = "fixed"
+	node.AddInstances(instances, true)
+	return true
 }
 func (node *Node) ConfigureInstances_Scaled(min int, max int) bool {
 	if node.Do("start") {
@@ -133,7 +129,7 @@ func (node *Node) GetRandomInstance(onlyActive bool) *Instance {
 			continue
 		}
 
-		return instance
+		return node.GetInstance(name)
 	}
 	return nil
 }
@@ -144,7 +140,9 @@ func (node *Node) GetInstance(name string) *Instance {
 	if name=="" {
 		for _, instance := range node.InstanceMap {
 			if instance.active {
-				return instance
+				if instance.Process() {
+					return instance
+				}
 			}
 		}
 		// there are no instances

--- a/node_fromyaml.go
+++ b/node_fromyaml.go
@@ -107,14 +107,17 @@ func (item *Node_Yaml) toNode(name string, log Log, conf *Conf) (*Node, error) {
 	// interpret the Instances value
 	if item.Instances=="" {
 		if item.Type=="command" {
-			item.Instances="temporary"
+			item.Instances="temporary" // command nodes default to temporary
 		} else {
-			item.Instances="single"
+			item.Instances="single" // all other nodes default to single
 		}
 	}
 
+	// convert the instances string to proper node instances, using the first value as an optional instance type
 	split := strings.Split(item.Instances, " ")
 	switch split[0] {
+		case "scaled":
+			fallthrough
 		case "scale":
 			var min, max int64
 			if len(split)<2 {
@@ -129,10 +132,14 @@ func (item *Node_Yaml) toNode(name string, log Log, conf *Conf) (*Node, error) {
 			}
 			node.ConfigureInstances_Scaled( int(min), int(max))
 
+		case "temp":
+			fallthrough
 		case "temporary":
 			node.ConfigureInstances_Temporary()
+
 		case "single":
 			node.ConfigureInstances_Single()
+
 		case "fixed":
 			if len(split)<2 {
 				split = []string{"unnamed"} // this was not properly configured, so just give a single instance name
@@ -140,7 +147,7 @@ func (item *Node_Yaml) toNode(name string, log Log, conf *Conf) (*Node, error) {
 				split = split[1:] // remove the "fixed" and assume that the rest are instance names
 			}
 			fallthrough
-		default:
+		default: // default is a fixed type, space delimited list of instances
 			node.ConfigureInstances_Fixed( split )
 	}
 

--- a/operation_run.go
+++ b/operation_run.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"strings"
+)
+
 type Operation_Run struct {
 	log Log
 
@@ -7,8 +11,19 @@ type Operation_Run struct {
 	Targets []string
 
 	cmd []string
+	instance string
 }
 func (operation *Operation_Run) Flags(flags []string) {
+	if len(flags)>0 && strings.HasPrefix(flags[0], "@") {
+		operation.instance = string(flags[0][1:])
+
+		if len(flags)>1 {
+			flags = flags[1:]
+		} else {
+			flags = []string{}
+		}
+	}
+
 	operation.cmd = flags
 }
 func (operation *Operation_Run) Run() {
@@ -16,49 +31,79 @@ func (operation *Operation_Run) Run() {
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:RUN")
-	operation.Nodes.Run(operation.Targets, operation.cmd)
+	operation.Nodes.Run(operation.Targets, operation.instance, operation.cmd)
 }
 
-func (nodes *Nodes) Run(targets []string, cmd []string) {
+func (nodes *Nodes) Run(targets []string, instance string, cmd []string) {
 	for _, target := range nodes.GetTargets(targets) {
 		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Run(cmd)
+		target.Run(instance, cmd)
 	}
 }
 
-func (node *Node) Run(cmd []string) bool {
+func (node *Node) Run(instanceid string, cmd []string) bool {
 	if node.Do("run") {
 
-		id := "run" // perhaps we should randomly generate this to allow for persistance run containers
+		var instance *Instance
+		var persistant bool
 
-		// 1. create a new temporary instance for a node
-		node.AddTemporaryInstance(id)
-		instance := node.GetInstance(id)
+		switch node.InstanceType {
+			case "temporary":
+				if instanceid=="" {
+					instanceid = "run" // perhaps we should randomly generate this to allow for persistance run containers
+				}
+				// create a new temporary instance for a node
+				node.AddTemporaryInstance(instanceid)
+				instance = node.GetInstance(instanceid)
+				persistant = false
+			case "single":
+				instanceid = "single"
+				fallthrough
+			default:
+				instance = node.GetInstance(instanceid)
+				persistant = true
+		}
 
-		// 2. create the container for the new instance
-		instance.Config.AttachStdin = true
-		instance.Config.AttachStdout = true
-		instance.Config.AttachStderr = true
-
-		if instance.Create(cmd, false) {
-
-		// 3. start the container (set up a remove)
-			ok := instance.Start(false)
-
-		// 4. attach to the container
-			if ok {
-				defer instance.Remove(true)
-				instance.Attach()
-				return true
-			} else {
-				node.log.Error("Could not start RUN container")
-				return false
-			}
-
-		} else {
-			node.log.Error("Could not create RUN container")
+		if instance!=nil {
+			return instance.Run(cmd, persistant)
 		}
 
 	}
+	return false
+}
+
+func (instance *Instance) Run(cmd []string, persistant bool) bool {
+
+	instance.Config.AttachStdin = true
+	instance.Config.AttachStdout = true
+	instance.Config.AttachStderr = true
+
+	// 1. get the container for the instance (create it if needed)
+	hasContainer := instance.HasContainer(false)
+	if !hasContainer {
+		hasContainer = instance.Create(cmd, false)
+	}
+	if hasContainer {
+
+	// 3. start the container (set up a remove)
+		ok := instance.Start(false)
+
+	// 4. attach to the container
+		if ok {
+			if !persistant {
+				// 5. remove the container (if not instructed to keep it)
+				defer instance.Remove(true)
+			}
+			instance.Attach()
+			return true
+		} else {
+			instance.Node.log.Error("Could not start RUN container")
+			return false
+		}
+
+	} else {
+		instance.Node.log.Error("Could not create RUN container")
+	}
+
 	return false
 }


### PR DESCRIPTION
This patch allows command nodes to have an Instance: definition in the YAML, to indicate that they can be persistant containers.

The original idea was to have run operation containers be reused for multiple command runs, so that caches and state could persist between calls.  This idea proved impossible, as docker container commands are set when the container is created, and cannot be changed.

The changes are not serious, and so the PR is being opened anyway.  There are certain cleanup changes included, and some decent documentation added at the same time.
