### PR TITLE
fix dependencies to single nodes

### DIFF
--- a/dependency.go
+++ b/dependency.go
@@ -78,6 +78,8 @@ func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance s
 				if randomTarget := targetNode.GetRandomInstance(true); randomTarget!=nil {
 					targetInstances = []*Instance{ randomTarget }
 				}
+			} else if targetNode.InstanceType=="single" && ( targetInstanceName=="" || targetInstanceName=="single" || fallbackInstance=="single" ) {
+				targetInstances = targetNode.FilterInstances([]string{"single"}, true)
 			} else {
 				targetInstances = targetNode.FilterInstances([]string{targetInstanceName, fallbackInstance}, true)
 			}

--- a/instance.go
+++ b/instance.go
@@ -109,6 +109,7 @@ func (node *Node) GetInstances(onlyActive bool) []*Instance {
 }
 func (node *Node) FilterInstances(filters []string, onlyActive bool) []*Instance {
 	instances := []*Instance{}
+
 	for name, _ := range node.InstanceMap {
 		instance := node.GetInstance(name)
 


### PR DESCRIPTION
Dependencies on single nodes were only working for single-single relationships before, this patch fixes that, so that any node can link or VolumeFrom a single node, and it will always connect to the one node container.
