### PR TITLE
Initial Help operation and help messages

### DIFF
--- a/coach.go
+++ b/coach.go
@@ -74,7 +74,7 @@ func main() {
 	log.DebugObject(LOG_SEVERITY_DEBUG, "OPERATION: ["+operationName+"] => flags :", operationFlags)
 
 	// get an operation object
-	operation := GetOperation(operationName, nodes, targets, client, &conf, log.ChildLog("OPERATION"))
+	operation := GetOperation(operationName, nodes, targets, &conf, log.ChildLog("OPERATION"))
 
 	log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Operation", operation);
 

--- a/log.go
+++ b/log.go
@@ -49,6 +49,15 @@ func (log *Log) Message(message string) {
 		)
 	}
 }
+func (log *Log) Note(message string) {
+	if (log.severity>=LOG_SEVERITY_MESSAGE) {
+		log.write(
+			LOG_SEVERITY_MESSAGE,
+			message,
+		)
+	}
+}
+
 func (log *Log) Warning(message string) {
 	if (log.severity>=LOG_SEVERITY_WARNING) {
 		log.write(

--- a/operation.go
+++ b/operation.go
@@ -56,6 +56,8 @@ func GetOperation(name string, nodes Nodes, targets []string, client *docker.Cli
 type Operation interface {
 	Flags(flags []string)
 	Run()
+
+	Help()
 }
 
 
@@ -74,4 +76,7 @@ func (operation *EmptyOperation) Flags(flags []string) {
 }
 func (operation *EmptyOperation) Run() {
 	operation.log.Message("No matching operation found :"+operation.name)
+}
+func (operation *EmptyOperation) Help() {
+
 }

--- a/operation.go
+++ b/operation.go
@@ -1,17 +1,17 @@
 package main
 
-import (
-	docker "github.com/fsouza/go-dockerclient"
-)
-
-func GetOperation(name string, nodes Nodes, targets []string, client *docker.Client, conf *Conf, log Log) Operation {
+func GetOperation(name string, nodes Nodes, targets []string, conf *Conf, log Log) Operation {
 
 	switch name {
-		case "init":
-			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, Targets: targets})
+		case "help":
+			return Operation(&Operation_Help{log:log.ChildLog("HELP"), conf: conf, Targets: targets})
 
 		case "info":
 			return Operation(&Operation_Info{log:log.ChildLog("INFO"), Nodes:nodes, Targets:targets})
+		// case "status":
+
+		case "init":
+			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, Targets: targets})
 
 		case "pull":
 			return Operation(&Operation_Pull{log:log.ChildLog("PULL"), Nodes:nodes, Targets:targets})
@@ -57,7 +57,7 @@ type Operation interface {
 	Flags(flags []string)
 	Run()
 
-	Help()
+	Help(topics []string)
 }
 
 
@@ -77,6 +77,9 @@ func (operation *EmptyOperation) Flags(flags []string) {
 func (operation *EmptyOperation) Run() {
 	operation.log.Message("No matching operation found :"+operation.name)
 }
-func (operation *EmptyOperation) Help() {
+func (operation *EmptyOperation) Help(topics []string) {
+	operation.log.Note(`Operation: MissingOperation
 
+	No related operation was found.
+`)
 }

--- a/operation_attach.go
+++ b/operation_attach.go
@@ -16,6 +16,11 @@ type Operation_Attach struct {
 func (operation *Operation_Attach) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Attach) Help() {
+
+}
+
 func (operation *Operation_Attach) Run() {
 	operation.Nodes.Attach(operation.Targets)
 }

--- a/operation_attach.go
+++ b/operation_attach.go
@@ -17,8 +17,11 @@ func (operation *Operation_Attach) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Attach) Help() {
+func (operation *Operation_Attach) Help(topics []string) {
+	operation.log.Note(`Operation: ATTACH
 
+Coach will attempt to attach to an existing container.
+`)
 }
 
 func (operation *Operation_Attach) Run() {

--- a/operation_build.go
+++ b/operation_build.go
@@ -25,6 +25,12 @@ func (operation *Operation_Build) Flags(flags []string) {
 		}
 	}
 }
+
+
+func (operation *Operation_Build) Help() {
+
+}
+
 func (operation *Operation_Build) Run() {
 	force := false
 	if operation.force == true {

--- a/operation_build.go
+++ b/operation_build.go
@@ -27,8 +27,11 @@ func (operation *Operation_Build) Flags(flags []string) {
 }
 
 
-func (operation *Operation_Build) Help() {
+func (operation *Operation_Build) Help(topics []string) {
+	operation.log.Note(`Operation: BUILD
 
+Coach will attempt to build a new docker image, for each target node that has a build setting.
+`)
 }
 
 func (operation *Operation_Build) Run() {

--- a/operation_commit.go
+++ b/operation_commit.go
@@ -13,6 +13,11 @@ type Operation_Commit struct {
 func (operation *Operation_Commit) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Commit) Help() {
+
+}
+
 func (operation *Operation_Commit) Run() {
 	operation.Nodes.Commit(operation.Targets, "/", map[string]string{"single":"latest"}, "")
 }

--- a/operation_commit.go
+++ b/operation_commit.go
@@ -14,8 +14,11 @@ func (operation *Operation_Commit) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Commit) Help() {
+func (operation *Operation_Commit) Help(topics []string) {
+	operation.log.Note(`Operation: COMMIT
 
+Coach will attempt to commit a container to it's image.
+`)
 }
 
 func (operation *Operation_Commit) Run() {

--- a/operation_create.go
+++ b/operation_create.go
@@ -23,8 +23,11 @@ func (operation *Operation_Create) Flags(flags []string) {
 	}
 }
 
-func (operation *Operation_Create) Help() {
+func (operation *Operation_Create) Help(topics []string) {
+	operation.log.Note(`Operation: CREATE
 
+Coach will attempt to create any node containers that should be active.
+`)
 }
 
 func (operation *Operation_Create) Run() {

--- a/operation_create.go
+++ b/operation_create.go
@@ -22,6 +22,11 @@ func (operation *Operation_Create) Flags(flags []string) {
 		}
 	}
 }
+
+func (operation *Operation_Create) Help() {
+
+}
+
 func (operation *Operation_Create) Run() {
 	force := false
 	if operation.force == true {

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -23,8 +23,13 @@ func (operation *Operation_Destroy) Flags(flags []string) {
 	}
 }
 
-func (operation *Operation_Destroy) Help() {
+func (operation *Operation_Destroy) Help(topics []string) {
+	operation.log.Note(`Operation: DESTROY
 
+Coach will attempt to remove any built images for target nodes.
+
+Coach will not remove an image for a node that does not build, which is the common case for nodes with an image, but no build setting.  This prevents deleting shared images that are not build targets.
+`)
 }
 
 func (operation *Operation_Destroy) Run() {

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -22,6 +22,11 @@ func (operation *Operation_Destroy) Flags(flags []string) {
 		}
 	}
 }
+
+func (operation *Operation_Destroy) Help() {
+
+}
+
 func (operation *Operation_Destroy) Run() {
 	force := false
 	if operation.force == true {

--- a/operation_help.go
+++ b/operation_help.go
@@ -1,0 +1,43 @@
+package main
+
+type Operation_Help struct {
+	log Log
+
+	conf *Conf
+
+	Nodes Nodes
+	Targets []string
+
+	flags []string
+}
+func (operation *Operation_Help) Flags(flags []string) {
+	operation.flags = flags
+}
+
+func (operation *Operation_Help) Help(topics []string) {
+	operation.log.Note(`Operation: HELP
+
+Coach will attempt to output a help message.
+
+The first topic passed in is assumed to be a help operation.
+`)
+}
+
+func (operation *Operation_Help) Run() {
+	operation.log.Message("running help operation")
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+
+// 	operation.Nodes.log = operation.log.ChildLog("OPERATION:HELP")
+	helpOperationName := "help"
+	helpOperationFlags := []string{}
+	if len(operation.flags)>0 {
+		helpOperationName = operation.flags[0]
+	}
+	if len(operation.flags)>1 {
+		helpOperationFlags = operation.flags[1:]
+	}
+
+	helpOperation := GetOperation(helpOperationName, operation.Nodes , operation.Targets, operation.conf, operation.log)
+	helpOperation.Help(helpOperationFlags)
+
+}

--- a/operation_info.go
+++ b/operation_info.go
@@ -20,8 +20,11 @@ func (operation *Operation_Info) Flags(flags []string) {
 	}
 }
 
-func (operation *Operation_Info) Help() {
+func (operation *Operation_Info) Help(topics []string) {
+	operation.log.Note(`Operation: INFO
 
+Coach will attempt to provide project information by investigating target images and containers.
+`)
 }
 
 func (operation *Operation_Info) Run() {

--- a/operation_info.go
+++ b/operation_info.go
@@ -19,6 +19,11 @@ func (operation *Operation_Info) Flags(flags []string) {
 		}
 	}
 }
+
+func (operation *Operation_Info) Help() {
+
+}
+
 func (operation *Operation_Info) Run() {
 
 	operation.log.Message("running info operation")

--- a/operation_init.go
+++ b/operation_init.go
@@ -58,6 +58,11 @@ func (operation *Operation_Init) Flags(flags []string) {
 
 	operation.handlerFlags = remainingFlags
 }
+
+func (operation *Operation_Init) Help() {
+
+}
+
 func (operation *Operation_Init) Run() {
 	var err error
 	var ok bool

--- a/operation_init.go
+++ b/operation_init.go
@@ -59,8 +59,11 @@ func (operation *Operation_Init) Flags(flags []string) {
 	operation.handlerFlags = remainingFlags
 }
 
-func (operation *Operation_Init) Help() {
+func (operation *Operation_Init) Help(topics []string) {
+	operation.log.Note(`Operation: INIT
 
+Coach will attempt to initialize a new coach project in the current folder.
+`)
 }
 
 func (operation *Operation_Init) Run() {

--- a/operation_pause.go
+++ b/operation_pause.go
@@ -12,8 +12,11 @@ func (operation *Operation_Pause) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Pause) Help() {
+func (operation *Operation_Pause) Help(topics []string) {
+	operation.log.Note(`Operation: PAUSE
 
+Coach will attempt to pause any target containers.
+`)
 }
 
 func (operation *Operation_Pause) Run() {

--- a/operation_pause.go
+++ b/operation_pause.go
@@ -11,6 +11,11 @@ type Operation_Pause struct {
 func (operation *Operation_Pause) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Pause) Help() {
+
+}
+
 func (operation *Operation_Pause) Run() {
 	operation.Nodes.Pause(operation.Targets)
 }

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -18,8 +18,13 @@ func (operation *Operation_Pull) Flags(flags []string) {
 	operation.Registry = "https://index.docker.io/v1/"
 }
 
-func (operation *Operation_Pull) Help() {
+func (operation *Operation_Pull) Help(topics []string) {
+	operation.log.Note(`Operation: PULL
 
+Coach will attempt to pull any node images, for nodes that have no build settings.
+
+Nodes that have build settings will not attempt to pull any images, as it is expected that those images will be created using the build operation.
+`)
 }
 
 func (operation *Operation_Pull) Run() {

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -17,6 +17,11 @@ type Operation_Pull struct {
 func (operation *Operation_Pull) Flags(flags []string) {
 	operation.Registry = "https://index.docker.io/v1/"
 }
+
+func (operation *Operation_Pull) Help() {
+
+}
+
 func (operation *Operation_Pull) Run() {
 	operation.log.Message("running pull operation")
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)

--- a/operation_remove.go
+++ b/operation_remove.go
@@ -22,6 +22,11 @@ func (operation *Operation_Remove) Flags(flags []string) {
 		}
 	}
 }
+
+func (operation *Operation_Remove) Help() {
+
+}
+
 func (operation *Operation_Remove) Run() {
 	force := false
 	if operation.force == true {

--- a/operation_remove.go
+++ b/operation_remove.go
@@ -23,8 +23,11 @@ func (operation *Operation_Remove) Flags(flags []string) {
 	}
 }
 
-func (operation *Operation_Remove) Help() {
+func (operation *Operation_Remove) Help(topics []string) {
+	operation.log.Note(`Operation: REMOVE
 
+Coach will attempt to remove all target node containers.
+`)
 }
 
 func (operation *Operation_Remove) Run() {

--- a/operation_run.go
+++ b/operation_run.go
@@ -27,8 +27,20 @@ func (operation *Operation_Run) Flags(flags []string) {
 	operation.cmd = flags
 }
 
-func (operation *Operation_Run) Help() {
+func (operation *Operation_Run) Help(topics []string) {
+	operation.log.Note(`Operation: RUN
 
+Coach will attempt a single command run on a node container.
+
+The run operation follows the following steps:
+- creates a new container using a new command (read from command line)
+- starts that container, output stdout and stderr
+- removes the started container
+
+The process is ideal for running single commands in volatile containers, which can disappear after execution.
+
+Containers can be persistant, but such containers are not as usefull, as the command cannot be changed.  In most cases, volatility can still work, as long as persistant file and folder maps are used to keep volatile information.
+`)
 }
 
 func (operation *Operation_Run) Run() {

--- a/operation_run.go
+++ b/operation_run.go
@@ -26,6 +26,11 @@ func (operation *Operation_Run) Flags(flags []string) {
 
 	operation.cmd = flags
 }
+
+func (operation *Operation_Run) Help() {
+
+}
+
 func (operation *Operation_Run) Run() {
 	operation.log.Message("running run operation")
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)

--- a/operation_start.go
+++ b/operation_start.go
@@ -11,6 +11,11 @@ type Operation_Start struct {
 func (operation *Operation_Start) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Start) Help() {
+
+}
+
 func (operation *Operation_Start) Run() {
 	operation.Nodes.Start(operation.Targets)
 }

--- a/operation_start.go
+++ b/operation_start.go
@@ -12,8 +12,11 @@ func (operation *Operation_Start) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Start) Help() {
+func (operation *Operation_Start) Help(topics []string) {
+	operation.log.Note(`Operation: START
 
+Coach will attempt to start target node containers.
+`)
 }
 
 func (operation *Operation_Start) Run() {

--- a/operation_stop.go
+++ b/operation_stop.go
@@ -13,8 +13,11 @@ func (operation *Operation_Stop) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Stop) Help() {
+func (operation *Operation_Stop) Help(topics []string) {
+	operation.log.Note(`Operation: STOP
 
+Coach will attempt to stop target node containers.
+`)
 }
 
 func (operation *Operation_Stop) Run() {

--- a/operation_stop.go
+++ b/operation_stop.go
@@ -12,6 +12,11 @@ type Operation_Stop struct {
 func (operation *Operation_Stop) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Stop) Help() {
+
+}
+
 func (operation *Operation_Stop) Run() {
 	operation.Nodes.Stop(operation.Targets, operation.force, operation.timeout)
 }

--- a/operation_unpause.go
+++ b/operation_unpause.go
@@ -11,6 +11,11 @@ type Operation_Unpause struct {
 func (operation *Operation_Unpause) Flags(flags []string) {
 
 }
+
+func (operation *Operation_Unpause) Help() {
+
+}
+
 func (operation *Operation_Unpause) Run() {
 	operation.Nodes.Unpause(operation.Targets)
 }

--- a/operation_unpause.go
+++ b/operation_unpause.go
@@ -12,8 +12,11 @@ func (operation *Operation_Unpause) Flags(flags []string) {
 
 }
 
-func (operation *Operation_Unpause) Help() {
+func (operation *Operation_Unpause) Help(topics []string) {
+	operation.log.Note(`Operation: UNPAUSE
 
+Coach will attempt to unpause target node containers.
+`)
 }
 
 func (operation *Operation_Unpause) Run() {


### PR DESCRIPTION
This patch adds the base for coach help, by adding a help method to the operation interface, and using that method in a new "help" operation.
Help messages are output using a new log.Note() method, which can diverge from log.Message() for different output formatting.

The patch also includes a small superfluous parameter from the GetOperation() function.  The function used to receive a Docker.Client reference, which it never used.
