### PR TITLE
make instances 0 based, which gives better token usage in certain cases

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -27,7 +27,7 @@ func (node *Node) ConfigureInstances_Scaled(min int, max int) bool {
 
 		node.InstanceType = "scaled"
 		for i:=0; i<max; i++ {
-			node.AddInstance(strconv.Itoa(i+1), i<min)
+			node.AddInstance(strconv.Itoa(i), i<min)
 		}
 		return true
 
@@ -80,6 +80,11 @@ func (node *Node) AddInstance(name string, active bool) {
 	instance.Init()
 	node.InstanceMap[name] = &instance
 }
+/**
+ * Add a temporary instance to a node
+ *
+ * @note there is currently no difference between a temporary and persistant instance.
+ */
 func (node *Node) AddTemporaryInstance(name string) {
 	node.AddInstance(name, true)
 }


### PR DESCRIPTION
This patches makes the scaled instance prepare method start instance names at "_0" instead of "_1"

The primary advantage of 0 based instances, is that the %INSTANCE token for the first instance is 0, which makes somethings pretty, like host ports for https servers.  

This isn't that usefull, it might warrant a push
