### PR TITLE
Changed some settings to allow better command node runs with tty

### DIFF
--- a/operation_attach.go
+++ b/operation_attach.go
@@ -73,9 +73,8 @@ func (instance *Instance) Attach() bool {
 
 		//Success chan struct{}
 
-		RawTerminal: false, // Use raw terminal? Usually true when the container contains a TTY.
+		RawTerminal: instance.Config.Tty, // Use raw terminal? Usually true when the container contains a TTY.
 	}
-
 
 	instance.Node.log.Message("ATTACHING TO INSTANCE CONTAINER ["+id+"]")
 	err := instance.Node.client.AttachToContainer( options )

--- a/operation_run.go
+++ b/operation_run.go
@@ -91,6 +91,19 @@ func (node *Node) Run(instanceid string, cmd []string) bool {
 
 func (instance *Instance) Run(cmd []string, persistant bool) bool {
 
+	// Set up some additional settings for TTY commands
+	if instance.Config.Tty==true {
+
+		// set a default hostname to make a prettier prompt
+		if instance.Config.Hostname=="" {
+			instance.Config.Hostname = instance.GetContainerName()
+		}
+
+		// make sure that all tty runs have openstdin
+		instance.Config.OpenStdin=true
+
+	}
+
 	instance.Config.AttachStdin = true
 	instance.Config.AttachStdout = true
 	instance.Config.AttachStderr = true

--- a/operation_run.go
+++ b/operation_run.go
@@ -14,7 +14,7 @@ type Operation_Run struct {
 	instance string
 }
 func (operation *Operation_Run) Flags(flags []string) {
-	if len(flags)>0 && strings.HasPrefix(flags[0], "@") {
+	if len(flags)>0 && strings.HasPrefix(flags[0], "->") {
 		operation.instance = string(flags[0][1:])
 
 		if len(flags)>1 {


### PR DESCRIPTION
Previously, the run operation was quite broken for some commands, which required better TTY integration.  The TTY config setting caused broken stream output.

This patch includes some changes to streamline TTY type commands, and to fix the container attach for such cases.
