### PR TITLE
allows targets to specify node instances

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -4,45 +4,45 @@ func GetOperation(name string, nodes Nodes, targets []string, conf *Conf, log Lo
 
 	switch name {
 		case "help":
-			return Operation(&Operation_Help{log:log.ChildLog("HELP"), conf: conf, Targets: targets})
+			return Operation(&Operation_Help{log:log.ChildLog("HELP"), conf: conf, targets: targets})
 
 		case "info":
-			return Operation(&Operation_Info{log:log.ChildLog("INFO"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Info{log:log.ChildLog("INFO"), nodes:nodes, targets:targets})
 		// case "status":
 
 		case "init":
-			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, Targets: targets})
+			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, targets: targets})
 
 		case "pull":
-			return Operation(&Operation_Pull{log:log.ChildLog("PULL"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Pull{log:log.ChildLog("PULL"), nodes:nodes, targets:targets})
 		case "build":
-			return Operation(&Operation_Build{log:log.ChildLog("BUILD"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Build{log:log.ChildLog("BUILD"), nodes:nodes, targets:targets})
 		case "destroy":
-			return Operation(&Operation_Destroy{log:log.ChildLog("DESTROY"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Destroy{log:log.ChildLog("DESTROY"), nodes:nodes, targets:targets})
 
 		case "run":
-			return Operation(&Operation_Run{log:log.ChildLog("RUN"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Run{log:log.ChildLog("RUN"), nodes:nodes, targets:targets})
 
 		case "create":
-			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), nodes:nodes, targets:targets})
 		case "remove":
-			return Operation(&Operation_Remove{log:log.ChildLog("REMOVE"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Remove{log:log.ChildLog("REMOVE"), nodes:nodes, targets:targets})
 
 		case "start":
-			return Operation(&Operation_Start{log:log.ChildLog("START"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Start{log:log.ChildLog("START"), nodes:nodes, targets:targets})
 		case "stop":
-			return Operation(&Operation_Stop{log:log.ChildLog("STOP"), Nodes:nodes, Targets:targets, timeout: 3})
+			return Operation(&Operation_Stop{log:log.ChildLog("STOP"), nodes:nodes, targets:targets, timeout: 3})
 
 		case "attach":
-			return Operation(&Operation_Attach{log:log.ChildLog("ATTACH"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Attach{log:log.ChildLog("ATTACH"), nodes:nodes, targets:targets})
 
 		case "pause":
-			return Operation(&Operation_Pause{log:log.ChildLog("PAUSE"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Pause{log:log.ChildLog("PAUSE"), nodes:nodes, targets:targets})
 		case "unpause":
-			return Operation(&Operation_Unpause{log:log.ChildLog("UNPAUSE"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Unpause{log:log.ChildLog("UNPAUSE"), nodes:nodes, targets:targets})
 
 		case "commit":
-			return Operation(&Operation_Commit{log:log.ChildLog("COMMIT"), Nodes:nodes, Targets:targets})
+			return Operation(&Operation_Commit{log:log.ChildLog("COMMIT"), nodes:nodes, targets:targets})
 
 		default:
 			return Operation(&EmptyOperation{name: name, log: log.ChildLog("EMPTY")})

--- a/operation_attach.go
+++ b/operation_attach.go
@@ -9,9 +9,8 @@ import (
 type Operation_Attach struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
-
+	nodes Nodes
+	targets []string
 }
 func (operation *Operation_Attach) Flags(flags []string) {
 
@@ -25,12 +24,16 @@ Coach will attempt to attach to an existing container.
 }
 
 func (operation *Operation_Attach) Run() {
-	operation.Nodes.Attach(operation.Targets)
+	operation.nodes.Attach(operation.targets)
 }
 
 func (nodes *Nodes) Attach(targets []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Attach([]string{})
+	for _, target := range nodes.GetTargets(targets, true) {
+		if target.node.Do("start") {
+			for _, instance := range target.instances {
+				instance.Attach()
+			}
+		}
 	}
 }
 

--- a/operation_build.go
+++ b/operation_build.go
@@ -10,8 +10,8 @@ import (
 type Operation_Build struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -41,16 +41,18 @@ func (operation *Operation_Build) Run() {
 	}
 
 	operation.log.Message("running build operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:BUILD")
-	operation.Nodes.Build(operation.Targets, force)
+	operation.nodes.Build(operation.targets, force)
 }
 
 func (nodes *Nodes) Build(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Build(force)
+	for _, target := range nodes.GetTargets(targets, true) {
+		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
+
+		// ignore target instances, and just build the node
+		target.node.Build(force)
 	}
 }
 

--- a/operation_create.go
+++ b/operation_create.go
@@ -7,9 +7,10 @@ import (
 type Operation_Create struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
+	cmd []string
 	force bool
 }
 func (operation *Operation_Create) Flags(flags []string) {
@@ -37,15 +38,19 @@ func (operation *Operation_Create) Run() {
 	}
 
 	operation.log.Message("running create operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:CREATE")
-	operation.Nodes.Create(operation.Targets, true, force)
+	operation.nodes.Create(operation.targets, operation.cmd, true, force)
 }
 
-func (nodes *Nodes) Create(targets []string, onlyActive bool, force bool) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Create([]string{}, onlyActive, force)
+func (nodes *Nodes) Create(targets []string, cmdOverride []string, onlyActive bool, force bool) {
+	for _, target := range nodes.GetTargets(targets, onlyActive) {
+		if target.node.Do("create") {
+			for _, instance := range target.instances {
+				instance.Create(cmdOverride, force)
+			}
+		}
 	}
 }
 

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -7,8 +7,8 @@ import (
 type Operation_Destroy struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -39,16 +39,16 @@ func (operation *Operation_Destroy) Run() {
 	}
 
 	operation.log.Message("running destroy operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:BUILD")
-	operation.Nodes.Destroy(operation.Targets, force)
+	operation.nodes.Destroy(operation.targets, force)
 }
 
 func (nodes *Nodes) Destroy(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Destroy(force)
+	for _, target := range nodes.GetTargets(targets, true) {
+		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
+		target.node.Destroy(force)
 	}
 }
 

--- a/operation_help.go
+++ b/operation_help.go
@@ -5,8 +5,8 @@ type Operation_Help struct {
 
 	conf *Conf
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	flags []string
 }
@@ -25,7 +25,7 @@ The first topic passed in is assumed to be a help operation.
 
 func (operation *Operation_Help) Run() {
 	operation.log.Message("running help operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:HELP")
 	helpOperationName := "help"
@@ -37,7 +37,7 @@ func (operation *Operation_Help) Run() {
 		helpOperationFlags = operation.flags[1:]
 	}
 
-	helpOperation := GetOperation(helpOperationName, operation.Nodes , operation.Targets, operation.conf, operation.log)
+	helpOperation := GetOperation(helpOperationName, operation.nodes , operation.targets, operation.conf, operation.log)
 	helpOperation.Help(helpOperationFlags)
 
 }

--- a/operation_info.go
+++ b/operation_info.go
@@ -9,8 +9,8 @@ import (
 type Operation_Info struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 }
 func (operation *Operation_Info) Flags(flags []string) {
 	for _, flag := range flags {
@@ -30,16 +30,16 @@ Coach will attempt to provide project information by investigating target images
 func (operation *Operation_Info) Run() {
 
 	operation.log.Message("running info operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:INFO")
-	operation.Nodes.Info(operation.Targets)
+	operation.nodes.Info(operation.targets)
 }
 
 func (nodes *Nodes) Info(targets []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Info()
+	for _, target := range nodes.GetTargets(targets, false) {
+		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
+		target.node.Info()
 	}
 }
 

--- a/operation_init.go
+++ b/operation_init.go
@@ -16,7 +16,7 @@ type Operation_Init struct {
 
 	force bool
 
-	Targets []string				// often not used, but perhaps it might be useful to define what nodes to create in some scenarios
+	targets []string				// often not used, but perhaps it might be useful to define what nodes to create in some scenarios
 }
 
 func (operation *Operation_Init) Flags(flags []string) {

--- a/operation_pause.go
+++ b/operation_pause.go
@@ -3,8 +3,8 @@ package main
 type Operation_Pause struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -20,12 +20,16 @@ Coach will attempt to pause any target containers.
 }
 
 func (operation *Operation_Pause) Run() {
-	operation.Nodes.Pause(operation.Targets)
+	operation.nodes.Pause(operation.targets)
 }
 
 func (nodes *Nodes) Pause(targets []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Pause([]string{}, false)
+	for _, target := range nodes.GetTargets(targets, true) {
+		if target.node.Do("start") {
+			for _, instance := range target.instances {
+				instance.Pause(false)
+			}
+		}
 	}
 }
 

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -9,8 +9,8 @@ import (
 type Operation_Pull struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	Registry string
 }
@@ -29,16 +29,16 @@ Nodes that have build settings will not attempt to pull any images, as it is exp
 
 func (operation *Operation_Pull) Run() {
 	operation.log.Message("running pull operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:BUILD")
-	operation.Nodes.Pull(operation.Targets, operation.Registry)
+	operation.nodes.Pull(operation.targets, operation.Registry)
 }
 
 func (nodes *Nodes) Pull(targets []string, registry string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Pull(registry)
+	for _, target := range nodes.GetTargets(targets, false) {
+		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
+		target.node.Pull(registry)
 	}
 }
 

--- a/operation_remove.go
+++ b/operation_remove.go
@@ -7,8 +7,8 @@ import (
 type Operation_Remove struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -37,15 +37,19 @@ func (operation *Operation_Remove) Run() {
 	}
 
 	operation.log.Message("running remove operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:REMOVE")
-	operation.Nodes.Remove(operation.Targets, force)
+	operation.nodes.Remove(operation.targets, force)
 }
 
 func (nodes *Nodes) Remove(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Remove([]string{}, force)
+	for _, target := range nodes.GetTargets(targets, !force) {
+		if target.node.Do("create") {
+			for _, instance := range target.instances {
+				instance.Remove(force)
+			}
+		}
 	}
 }
 

--- a/operation_run.go
+++ b/operation_run.go
@@ -1,9 +1,5 @@
 package main
 
-import (
-	"strings"
-)
-
 type Operation_Run struct {
 	log Log
 
@@ -14,16 +10,6 @@ type Operation_Run struct {
 	instance string
 }
 func (operation *Operation_Run) Flags(flags []string) {
-	if len(flags)>0 && strings.HasPrefix(flags[0], "->") {
-		operation.instance = string(flags[0][1:])
-
-		if len(flags)>1 {
-			flags = flags[1:]
-		} else {
-			flags = []string{}
-		}
-	}
-
 	operation.cmd = flags
 }
 

--- a/operation_run.go
+++ b/operation_run.go
@@ -7,8 +7,8 @@ import (
 type Operation_Run struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	cmd []string
 	instance string
@@ -45,16 +45,11 @@ Containers can be persistant, but such containers are not as usefull, as the com
 
 func (operation *Operation_Run) Run() {
 	operation.log.Message("running run operation")
-	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.Targets)
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
-// 	operation.Nodes.log = operation.log.ChildLog("OPERATION:RUN")
-	operation.Nodes.Run(operation.Targets, operation.instance, operation.cmd)
-}
-
-func (nodes *Nodes) Run(targets []string, instance string, cmd []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.log = nodes.log.ChildLog("NODE:"+target.Name)
-		target.Run(instance, cmd)
+	for _, target := range operation.nodes.GetTargets(operation.targets, true) {
+		target.node.log = operation.nodes.log.ChildLog("NODE:"+target.node.Name)
+		target.node.Run(operation.instance, operation.cmd)
 	}
 }
 

--- a/operation_start.go
+++ b/operation_start.go
@@ -3,8 +3,8 @@ package main
 type Operation_Start struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -20,12 +20,16 @@ Coach will attempt to start target node containers.
 }
 
 func (operation *Operation_Start) Run() {
-	operation.Nodes.Start(operation.Targets)
+	operation.nodes.Start(operation.targets, operation.force)
 }
 
-func (nodes *Nodes) Start(targets []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Start([]string{}, false)
+func (nodes *Nodes) Start(targets []string, force bool) {
+	for _, target := range nodes.GetTargets(targets, !force) {
+		if target.node.Do("start") {
+			for _, instance := range target.instances {
+				instance.Start(force)
+			}
+		}
 	}
 }
 

--- a/operation_stop.go
+++ b/operation_stop.go
@@ -3,8 +3,8 @@ package main
 type Operation_Stop struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 	timeout uint
@@ -21,12 +21,16 @@ Coach will attempt to stop target node containers.
 }
 
 func (operation *Operation_Stop) Run() {
-	operation.Nodes.Stop(operation.Targets, operation.force, operation.timeout)
+	operation.nodes.Stop(operation.targets, operation.force, operation.timeout)
 }
 
 func (nodes *Nodes) Stop(targets []string, force bool, timeout uint) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Stop([]string{}, force, timeout)
+	for _, target := range nodes.GetTargets(targets, !force) {
+		if target.node.Do("start") {
+			for _, instance := range target.instances {
+				instance.Stop(force, timeout)
+			}
+		}
 	}
 }
 

--- a/operation_unpause.go
+++ b/operation_unpause.go
@@ -3,8 +3,8 @@ package main
 type Operation_Unpause struct {
 	log Log
 
-	Nodes Nodes
-	Targets []string
+	nodes Nodes
+	targets []string
 
 	force bool
 }
@@ -20,12 +20,16 @@ Coach will attempt to unpause target node containers.
 }
 
 func (operation *Operation_Unpause) Run() {
-	operation.Nodes.Unpause(operation.Targets)
+	operation.nodes.Unpause(operation.targets, operation.force)
 }
 
-func (nodes *Nodes) Unpause(targets []string) {
-	for _, target := range nodes.GetTargets(targets) {
-		target.Unpause([]string{}, false)
+func (nodes *Nodes) Unpause(targets []string, force bool) {
+	for _, target := range nodes.GetTargets(targets, !force) {
+		if target.node.Do("start") {
+			for _, instance := range target.instances {
+				instance.Unpause(force)
+			}
+		}
 	}
 }
 

--- a/targets.go
+++ b/targets.go
@@ -1,34 +1,80 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/twmb/algoimpl/go/graph"
 )
 
-func (nodes Nodes) GetTargets(targets []string) []*Node {
-	log := nodes.log.ChildLog("TARGETS")
+type Target struct {
+	node *Node
+	instances []*Instance
+}
 
-	Targets := []*Node{}				// ordered list of targets
-	added := map[string]bool{}	// track which keys have already been added, to prevent repeats
+func addNodeToTargets(targets []*Target, node *Node, instances []*Instance) []*Target {
 
-log.DebugObject( LOG_SEVERITY_DEBUG, "TARGETS", targets)
-	if len(targets)==0 {
-		targets = append(targets, "$all")
+	for _, eachTarget := range targets {
+		if eachTarget.node.Name==node.Name {
+			// The target node has already been added, so we just need to confirm instances
+
+			for _, addInstance := range instances {
+				found := false
+				for _, existingInstance := range eachTarget.instances {
+					if addInstance.Name==existingInstance.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					eachTarget.instances = append(eachTarget.instances, addInstance)
+				}
+			}
+
+			return targets
+		}
 	}
 
-	for _, target := range targets {
+	// this is a new target node, so add all of the instances
+	target := Target{node:node, instances:instances}
+	targets = append(targets, &target)
+	return targets
+}
+
+func targetStringSeparate(target string) (node string, instances []string) {
+	separated := strings.Split(target, ".")
+	if len(separated)>1 {
+		return separated[0], separated[1:]
+	} else {
+		return separated[0], []string{}
+	}
+}
+
+func (nodes Nodes) GetTargets(targetNames []string, onlyActive bool) []*Target {
+	log := nodes.log.ChildLog("TARGETS")
+
+	targets := []*Target{}				// ordered list of targets
+
+	log.DebugObject( LOG_SEVERITY_DEBUG, "TARGETS", targetNames)
+
+	if len(targetNames)==0 {
+		targetNames = append(targetNames, "$all")
+	}
+
+	for _, target := range targetNames {
 		prefix := target[0:1]
 		switch prefix {
 			case "$": // note that it is impossible to pass these in on the command line
-				switch target[1:] {
+				target = string(target[1:])
+				switch target {
 					case "all":
 						for name, _ := range nodes.Map {
-							if _, ok := added[target]; ok {
-								// already added this target
-								continue
-							}
 							if node, ok := nodes.GetNode(name); ok {
-								Targets = append(Targets, node)
-								added[name] = true
+								_, instances := targetStringSeparate(target)
+								if len(instances)==0 {
+									targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+								} else {
+									targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
+								}
 							}
 						}
 				}
@@ -37,13 +83,13 @@ log.DebugObject( LOG_SEVERITY_DEBUG, "TARGETS", targets)
 				target = string(target[1:])
 				for name, node := range nodes.Map {
 					if node.NodeType==target {
-						if _, ok := added[target]; ok {
-							// already added this target
-							continue
-						}
 						if node, ok := nodes.GetNode(name); ok {
-							Targets = append(Targets, node)
-							added[name] = true
+							_, instances := targetStringSeparate(target)
+							if len(instances)==0 {
+								targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+							} else {
+								targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
+							}
 						}
 					}
 				}
@@ -52,14 +98,12 @@ log.DebugObject( LOG_SEVERITY_DEBUG, "TARGETS", targets)
 				target = string(target[1:])
 				fallthrough
 			default:
-				if _, ok := nodes.Map[target]; ok {
-					if _, ok := added[target]; ok {
-						// already added this target
-						continue
-					}
-					if node, ok := nodes.GetNode(target); ok {
-						Targets = append(Targets, node)
-						added[target] = true
+				name, instances := targetStringSeparate(target)
+				if node, ok := nodes.GetNode(name); ok {
+					if len(instances)==0 {
+						targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+					} else {
+						targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
 					}
 				} else {
 					nodes.log.Error("Unknown target passed: "+target)
@@ -68,45 +112,48 @@ log.DebugObject( LOG_SEVERITY_DEBUG, "TARGETS", targets)
 		}
 	}
 
-	log.DebugObject(LOG_SEVERITY_DEBUG_STAAAP, "Get Targets:", Targets)
+	log.DebugObject(LOG_SEVERITY_DEBUG_STAAAP, "Get Targets:", targets)
 
-	sorted := nodes.SortTargets(Targets)
+	sorted := nodes.SortTargets(targets)
 
 	log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Get Sorted:", sorted)
 
 	return sorted
 }
-func (nodes *Nodes) SortTargets(targets []*Node) []*Node {
+func (nodes *Nodes) SortTargets(targets []*Target) []*Target {
 	log := nodes.log.ChildLog("SORT")
 
 	g := graph.New(graph.Directed)
 	graphNodes := make(map[string]graph.Node, 0)
+	targetMap := map[string]*Target{}
 
 	// use targets to create graph nodes
 	for _, target := range targets {
-		graphNodes[target.Name] = g.MakeNode()
-		*graphNodes[target.Name].Value = target.Name
-		log.Debug(LOG_SEVERITY_DEBUG_STAAAP, "ADDING TARGET:"+target.Name)
+		name := target.node.Name
+		targetMap[name] = target
+		graphNodes[name] = g.MakeNode()
+		*graphNodes[name].Value = name
+		log.Debug(LOG_SEVERITY_DEBUG_STAAAP, "ADDING TARGET:"+name)
 	}
 	// use dependencies to set graph edges
 	for _, target := range targets {
-		if target.Dependencies!=nil {
-			for dependency, _ := range target.Dependencies {
+		if target.node.Dependencies!=nil {
+			for dependency, _ := range target.node.Dependencies {
 				if _, ok := graphNodes[dependency]; ok {
-					g.MakeEdge(graphNodes[dependency], graphNodes[target.Name])
-					log.Debug(LOG_SEVERITY_DEBUG_STAAAP, "ADDING EDGE:"+dependency+"<-"+target.Name)
+					g.MakeEdge(graphNodes[dependency], graphNodes[target.node.Name])
+					log.Debug(LOG_SEVERITY_DEBUG_STAAAP, "ADDING EDGE:"+dependency+"<-"+target.node.Name)
 				}
 			}
 		}
 	}
 
 	log.Debug( LOG_SEVERITY_DEBUG_STAAAP, "GETTING SORTED ITEMS")
-	sorted := []*Node{}
+	sorted := []*Target{}
 	for _,graphNode := range g.TopologicalSort() {
 		value := *graphNode.Value
 		log.DebugObject( LOG_SEVERITY_DEBUG_STAAAP, "SORTED ITEM:", value)
 		if name, ok := value.(string); ok {
-			sorted = append(sorted, nodes.Map[name])
+			sorted = append(sorted, targetMap[name])
 		}
 	}
 


### PR DESCRIPTION
This patch allows execution targets to specify which instances to target.

Previously : 

```
$/> coach @www @fpm @db start
```

Now optionally : 

```
$/> coach @www.3 @www.2 @fpm.3 @fpm.2 @db start
```

Using the "." separator, you can optionally specify which of the node instances to act on.

These instance indicators are processed, but ignored for operations which act on the node level, such as build, pull and destroy.  Info also ignores this, but will be rewritten soon.
