### PR TITLE
Add lots of help topics

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -78,8 +78,8 @@ func (operation *EmptyOperation) Run() {
 	operation.log.Message("No matching operation found :"+operation.name)
 }
 func (operation *EmptyOperation) Help(topics []string) {
-	operation.log.Note(`Operation: MissingOperation
+	operation.log.Note(`Topic: Missing
 
-	No related operation was found.
+	No related help topic could be found.
 `)
 }

--- a/operation_attach.go
+++ b/operation_attach.go
@@ -20,6 +20,17 @@ func (operation *Operation_Attach) Help(topics []string) {
 	operation.log.Note(`Operation: ATTACH
 
 Coach will attempt to attach to an existing container.
+
+SYNTAX:
+    $/> coach {target} attach
+
+  {target} what target node instance the operation should process ($/> coach help targets)
+
+ACCESS:
+  - This operation processed only nodes with the "start" access.  This excludes build, volume and command containers.
+
+NOTES:
+  - The attach operation is really meant to be used to attach to a single instance target, but it multiple instances are targeted, then the operation will attach to each container in sequence.  To target a specific container use an instance style target (for more help checkout $/> coach help target).
 `)
 }
 

--- a/operation_build.go
+++ b/operation_build.go
@@ -31,6 +31,20 @@ func (operation *Operation_Build) Help(topics []string) {
 	operation.log.Note(`Operation: BUILD
 
 Coach will attempt to build a new docker image, for each target node that has a build setting.
+
+The operation will look for a Build: setting inside the node, and try to find a matching Dockerfile at the suggested path.  The path can be relative to the project root, or absolute.
+
+SYNTAX:
+    $/> coach {targets} build
+
+  {targets} what target nodes the operation should process ($/> coach help targets)
+
+ACCESS:
+  - this operation processes only nodes with the "build" access.  This includes only nodes with a Build: setting.
+
+NOTES:
+- a node that can be built should have a Build: setting, which points to a project path that contains the Dockerfile.
+- while {targets} globally can specify particular node instances, that information is ignored for this operation, as images are built for all instances of a node.
 `)
 }
 

--- a/operation_commit.go
+++ b/operation_commit.go
@@ -53,6 +53,18 @@ func (operation *Operation_Commit) Help(topics []string) {
 	operation.log.Note(`Operation: COMMIT
 
 Coach will attempt to commit a container to it's image.
+
+SYNTAX:
+    $/> coach {targets} commit [--tag {tag}] [--repo {repo}] [--message "{message}"]
+
+  {targets} what target node instances the operation should process ($/> coach help targets)
+  --tag "{tag}" : what image tag to use (default: "latest")
+  --repo "{repo}" : what image repository to commit to (default: local)
+  --message "{message}" : what commit message to use
+
+ACCESS:
+  - only nodes with the "commit" access are processed.  This excludes build nodes
+
 `)
 }
 

--- a/operation_create.go
+++ b/operation_create.go
@@ -28,6 +28,14 @@ func (operation *Operation_Create) Help(topics []string) {
 	operation.log.Note(`Operation: CREATE
 
 Coach will attempt to create any node containers that should be active.
+
+Syntax:
+    $/> coach {targets} create
+
+  {targets} what target node instances the operation should process ($/> coach help targets)
+
+Access:
+  - only nodes with the "create" access are processed.  This excludes build and command nodes
 `)
 }
 

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -28,7 +28,16 @@ func (operation *Operation_Destroy) Help(topics []string) {
 
 Coach will attempt to remove any built images for target nodes.
 
-Coach will not remove an image for a node that does not build, which is the common case for nodes with an image, but no build setting.  This prevents deleting shared images that are not build targets.
+SYNTAX:
+    $/> coach {targets} destroy
+
+  {targets} what target nodes the operation should process ($/> coach help targets)
+
+ACCESS:
+  - this opertion will only process nodes with "build" access.  This includes only nodes with the Build: settings declared.
+
+NOTE:
+- Coach will try not to remove an image for a node that does not build, which is the common case for nodes with an image, but no build setting.  This prevents deleting shared images that are not build targets.
 `)
 }
 

--- a/operation_help.go
+++ b/operation_help.go
@@ -28,16 +28,50 @@ func (operation *Operation_Help) Run() {
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
 // 	operation.Nodes.log = operation.log.ChildLog("OPERATION:HELP")
-	helpOperationName := "help"
-	helpOperationFlags := []string{}
+	helpTopicName := "help"
+	helpTopicFlags := []string{}
 	if len(operation.flags)>0 {
-		helpOperationName = operation.flags[0]
+		helpTopicName = operation.flags[0]
 	}
 	if len(operation.flags)>1 {
-		helpOperationFlags = operation.flags[1:]
+		helpTopicFlags = operation.flags[1:]
 	}
 
-	helpOperation := GetOperation(helpOperationName, operation.nodes , operation.targets, operation.conf, operation.log)
-	helpOperation.Help(helpOperationFlags)
+	switch helpTopicName {
+		case "topics":
+			operation.Topic_Targets(helpTopicFlags)
 
+		default: //assume this is an operation call
+			helpTopic := GetOperation(helpTopicName, operation.nodes , operation.targets, operation.conf, operation.log)
+			helpTopic.Help(helpTopicFlags)
+	}
+}
+
+func (operation *Operation_Help) Topic_Targets(flags []string) {
+	operation.log.Note(`Topic: Targets
+
+Targets are a global setting used to determine which node and/or node instances an operation should used.  Targets are strings that define a type of node, a particular node, or a particular node instance.
+
+Coach accepts as a global flag, a list of targets in the following form:
+
+%{type} : all nodes of a certain type.  E.g.  %command
+%{type}:{instance} : the {instance} of any nodes of type {type}
+
+@{node} : all instances of a node named {node}
+@{node} : a particular {instance} instance from a node named {node}
+
+Here are some examples:
+
+    $/> coach @db start
+    Start all of the "db" node instances
+
+    $/> coach @www.1 @www.2 remove
+    remove the "1" and "2" instances from the "www" node
+
+    $/> coach %service stop
+    stop all nodes of type "service"
+
+    $/> coach %volume:single commit
+    commit the "single" instance of all nodes of type "volume"
+`)
 }

--- a/operation_help.go
+++ b/operation_help.go
@@ -17,7 +17,31 @@ func (operation *Operation_Help) Flags(flags []string) {
 func (operation *Operation_Help) Help(topics []string) {
 	operation.log.Note(`Operation: HELP
 
-Coach will attempt to output a help message.
+Coach will attempt to output help messages.  The message will match either a topic, or an operation.
+
+TOPICS:
+  cli
+    cli:targets (targets)
+
+	settings
+	  settings:targets (targets)
+	  settings:secrets (secrets)
+
+OPERATIONS:
+
+  init
+
+	build
+	pull
+	destroy
+
+	create
+	remove
+
+	start
+	pause
+	unpause
+	remove
 
 The first topic passed in is assumed to be a help operation.
 `)
@@ -38,8 +62,23 @@ func (operation *Operation_Help) Run() {
 	}
 
 	switch helpTopicName {
-		case "topics":
-			operation.Topic_Targets(helpTopicFlags)
+		case "cli":
+			operation.Topic_CLI(helpTopicFlags)
+		case "targets":
+			fallthrough
+		case "cli:targets":
+			operation.Topic_CLI_Targets(helpTopicFlags)
+
+		case "settings":
+			operation.Topic_Settings(helpTopicFlags)
+		case "tokens":
+			fallthrough
+		case "settings:tokens":
+			operation.Topic_Settings_Tokens(helpTopicFlags)
+		case "secrets":
+			fallthrough
+		case "settings:secrets":
+			operation.Topic_Settings_Secrets(helpTopicFlags)
 
 		default: //assume this is an operation call
 			helpTopic := GetOperation(helpTopicName, operation.nodes , operation.targets, operation.conf, operation.log)
@@ -47,8 +86,15 @@ func (operation *Operation_Help) Run() {
 	}
 }
 
-func (operation *Operation_Help) Topic_Targets(flags []string) {
-	operation.log.Note(`Topic: Targets
+func (operation *Operation_Help) Topic_CLI(flags []string) {
+	operation.log.Note(`Topic: CLI
+
+{CLI HELP}
+
+`)
+}
+func (operation *Operation_Help) Topic_CLI_Targets(flags []string) {
+	operation.log.Note(`Topic: CLI:Targets
 
 Targets are a global setting used to determine which node and/or node instances an operation should used.  Targets are strings that define a type of node, a particular node, or a particular node instance.
 
@@ -73,5 +119,61 @@ Here are some examples:
 
     $/> coach %volume:single commit
     commit the "single" instance of all nodes of type "volume"
+`)
+}
+
+
+func (operation *Operation_Help) Topic_Settings_Tokens(flags []string) {
+	operation.log.Note(`Topic: Settings:Tokens
+
+Tokens are settings key-value string pairs, that can be used for subsitution in later configurations.  Tokens defined in one state, are used for text replacement in all further configuration files, where possible.
+
+Tokens are typically used to:
+  - allow settings to be reused across projects with minimal changes (which may allow templating in the future)
+	- reduce duplicate settings across nodes, by centralizing values in the conf.yml
+  - keep some sensitive values out of shared configuration (typically secrets)
+  - allow some containers to use user specific values, instead of project specific values
+
+SOURCES:
+
+Tokens are typically kept in one of the following locations (list in order of loading):
+
+- .coach/conf.yml:Tokens: => in the conf.yml is a Tokens: map.  This map is typically used for values that are used across multiple nodes.
+
+- !/.coach/secrets/secrets.yml => in the user secrets.yml.  This map typically keeps user specific container ENV values such as passwords for user specific services that containers may use.
+- .coach/secrets/secrets.yml => in the project secrets.yml.  This map is typically used to keep project specific ID and token values used as ENV variables in containers, but that should not be kept in any source repository.
+
+For more information about secrets see $/> coach help secrets
+
+`)
+}
+
+
+func (operation *Operation_Help) Topic_Settings(flags []string) {
+	operation.log.Note(`Topic: Settings
+
+{SETTINGS HELP}
+
+`)
+}
+func (operation *Operation_Help) Topic_Settings_Secrets(flags []string) {
+	operation.log.Note(`Topic: Settings:Secrets
+
+Secrets are just tokens, but they tend to be kept in locations that are easy to exclude from source versioning.
+
+For more information about tokens, see $/> coach help tokens
+
+User secrets allow users to have local values that are keyed for services that may be used in containers, that are not to be shared with other users, buy may be shared across projects.
+Project secrets keep secret tokens separate from conf tokens.  The project secrets could be tailored to each project user, or distributed separately from project source code.
+
+NOTE:
+  - tokens are not protected in any way during coach execution.
+
+SOURCES:
+
+Secrets are typically kept in one of the following locations (list in order of loading):
+
+- !/.coach/secrets/secrets.yml => in the user secrets.yml.  This map typically keeps user specific container ENV values such as passwords for user specific services that containers may use.
+- .coach/secrets/secrets.yml => in the project secrets.yml.  This map is typically used to keep project specific ID and token values used as ENV variables in containers, but that should not be kept in any source repository.
 `)
 }

--- a/operation_help.go
+++ b/operation_help.go
@@ -80,6 +80,9 @@ func (operation *Operation_Help) Run() {
 		case "settings:secrets":
 			operation.Topic_Settings_Secrets(helpTopicFlags)
 
+		case "operations":
+			operation.Topic_Operations(helpTopicFlags)
+
 		default: //assume this is an operation call
 			helpTopic := GetOperation(helpTopicName, operation.nodes , operation.targets, operation.conf, operation.log)
 			helpTopic.Help(helpTopicFlags)
@@ -89,7 +92,11 @@ func (operation *Operation_Help) Run() {
 func (operation *Operation_Help) Topic_CLI(flags []string) {
 	operation.log.Note(`Topic: CLI
 
-{CLI HELP}
+The CLI is the primary means of running coach.  The goal is typically to run a coach operation, on a number of coach nodes, or coach node instances.
+
+SEE ALSO:
+- cli:targets : $/> coach help cli:targets
+- operations : $/> coach help operations
 
 `)
 }
@@ -175,5 +182,14 @@ Secrets are typically kept in one of the following locations (list in order of l
 
 - !/.coach/secrets/secrets.yml => in the user secrets.yml.  This map typically keeps user specific container ENV values such as passwords for user specific services that containers may use.
 - .coach/secrets/secrets.yml => in the project secrets.yml.  This map is typically used to keep project specific ID and token values used as ENV variables in containers, but that should not be kept in any source repository.
+`)
+}
+
+
+func (operation *Operation_Help) Topic_Operations(flags []string) {
+	operation.log.Note(`Topic: Operations
+
+{OPERATIONS HELP}
+
 `)
 }

--- a/operation_info.go
+++ b/operation_info.go
@@ -24,6 +24,12 @@ func (operation *Operation_Info) Help(topics []string) {
 	operation.log.Note(`Operation: INFO
 
 Coach will attempt to provide project information by investigating target images and containers.
+
+SYNTAX:
+    $/> coach {targets} info
+
+  {targets} what target nodes the operation should process ($/> coach help targets)
+
 `)
 }
 

--- a/operation_init.go
+++ b/operation_init.go
@@ -63,6 +63,22 @@ func (operation *Operation_Init) Help(topics []string) {
 	operation.log.Note(`Operation: INIT
 
 Coach will attempt to initialize a new coach project in the current folder.
+
+SYNTAX:
+    $/> coach init [ {type} {type flags} ]
+
+EXAMPLES:
+
+    $/> coach init
+    $/> coach init default
+    Populate the current path with default settings
+
+    $/> coach init user {template}
+    Uses the contents of ~/.coach/templates to populate the current folder
+
+    $/> coach init git https://github.com/aleksijohansson/docker-drupal-coach.git
+    Clones the target git URL to the current path
+
 `)
 }
 

--- a/operation_pause.go
+++ b/operation_pause.go
@@ -16,6 +16,16 @@ func (operation *Operation_Pause) Help(topics []string) {
 	operation.log.Note(`Operation: PAUSE
 
 Coach will attempt to pause any target containers.
+
+SYNTAX:
+    $/> coach {targets} pause
+
+	{targets} what target node instances the operation should process ($/> coach help targets)
+
+ACCESS:
+  - This operation processed only nodes with the "start" access.  This excludes build, volume and command containers
+
+NOTE:
 `)
 }
 

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -23,7 +23,17 @@ func (operation *Operation_Pull) Help(topics []string) {
 
 Coach will attempt to pull any node images, for nodes that have no build settings.
 
-Nodes that have build settings will not attempt to pull any images, as it is expected that those images will be created using the build operation.
+
+SYNTAX:
+    $/> coach {targets} pull
+
+  {targets} what target nodes the operation should process ($/> coach help targets)
+
+ACCESS:
+  - this operation processes only nodes with the "pull" access.  This includes only nodes without a Build: setting, but a Config: Image: setting.
+
+NOTES:
+  - Nodes that have build settings will not attempt to pull any images, as it is expected that those images will be created using the build operation.
 `)
 }
 

--- a/operation_remove.go
+++ b/operation_remove.go
@@ -27,6 +27,14 @@ func (operation *Operation_Remove) Help(topics []string) {
 	operation.log.Note(`Operation: REMOVE
 
 Coach will attempt to remove all target node containers.
+
+SYNTAX:
+    $/> coach {targets} remove
+
+	{targets} what target node instances the operation should process ($/> coach help targets)
+
+ACCESS:
+  - only nodes with the "create" access are processed.  This excludes build and command nodes
 `)
 }
 

--- a/operation_run.go
+++ b/operation_run.go
@@ -25,7 +25,17 @@ The run operation follows the following steps:
 
 The process is ideal for running single commands in volatile containers, which can disappear after execution.
 
-Containers can be persistant, but such containers are not as usefull, as the command cannot be changed.  In most cases, volatility can still work, as long as persistant file and folder maps are used to keep volatile information.
+SYNTAX:
+    $/> coach {target} run {cmd}
+
+	{target} what target node instance the operation should process ($/> coach help targets)
+	{cmd} a list of flags to pass into the container.  These can be flags added passed to the container entrypoint, or full command replacement.
+
+NOTE:
+- Containers can be persistant, but such containers are generally not usefull, as the container command cannot be changed.  In most cases, command container volatility can still work, as long as persistant file and folder binds/maps are used to keep volatile information outside of the container.
+
+TODO:
+- Allow overriding of a container entrypoint via a flag?
 `)
 }
 

--- a/operation_start.go
+++ b/operation_start.go
@@ -16,6 +16,14 @@ func (operation *Operation_Start) Help(topics []string) {
 	operation.log.Note(`Operation: START
 
 Coach will attempt to start target node containers.
+
+SYNTAX:
+    $/> coach {targets} start
+
+	{targets} what target node instances the operation should process ($/> coach help targets)
+
+ACCESS:
+  - This operation processed only nodes with the "start" access.  This excludes build, volume and command containers.
 `)
 }
 

--- a/operation_stop.go
+++ b/operation_stop.go
@@ -17,6 +17,15 @@ func (operation *Operation_Stop) Help(topics []string) {
 	operation.log.Note(`Operation: STOP
 
 Coach will attempt to stop target node containers.
+
+SYNTAX:
+    $/> coach {targets} stop
+
+	{targets} what target node instances the operation should process ($/> coach help targets)
+
+ACCESS:
+  - This operation processed only nodes with the "start" access.  This excludes build, volume and command containers.
+
 `)
 }
 

--- a/operation_unpause.go
+++ b/operation_unpause.go
@@ -16,6 +16,14 @@ func (operation *Operation_Unpause) Help(topics []string) {
 	operation.log.Note(`Operation: UNPAUSE
 
 Coach will attempt to unpause target node containers.
+
+SYNTAX:
+    $/> coach {targets} unpause
+
+	{targets} what target node instances the operation should process ($/> coach help targets)
+
+ACCESS:
+  - This operation processed only nodes with the "start" access.  This excludes build, volume and command containers.
 `)
 }
 


### PR DESCRIPTION
This patch only adds help copy and help topics.

Operations: additional details for help

Help: additional topics:
- targets : show how to use targets.

This is meant to target: https://github.com/james-nesbitt/coach/issues/19
