### PR TITLE
only load node image list and instance container list when needed

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,7 +98,6 @@ func MatchImages(client *docker.Client, imagePrefix string) []docker.APIImages {
 	return images
 }
 
-
 func (node *Node) GetImages()  []docker.APIImages {
 	return MatchImages(node.client, node.GetImageName())
 }

--- a/instance.go
+++ b/instance.go
@@ -174,11 +174,12 @@ type Instance struct {
 	Config docker.Config
 	HostConfig docker.HostConfig
 
+	Containers []docker.APIContainers
+
 	active bool											// should this instance be active for operations (or is it dormant, perhaps for scaling)
 	processed bool									// has this instance run .Process()
 }
 func (instance *Instance) Init() bool {
-	instance.processed = false
 	return true
 }
 func (instance *Instance) Process() bool {
@@ -188,6 +189,8 @@ func (instance *Instance) Process() bool {
 
 	instance.Config = instance.Node.instanceConfig(instance.Name)
 	instance.HostConfig = instance.Node.instanceHostConfig(instance.Name)
+
+	instance.Containers = MatchContainers(instance.Node.client, instance.GetContainerName(), false)
 
 	instance.processed = true
 	return true

--- a/instance.go
+++ b/instance.go
@@ -174,8 +174,6 @@ type Instance struct {
 	Config docker.Config
 	HostConfig docker.HostConfig
 
-	Containers []docker.APIContainers
-
 	active bool											// should this instance be active for operations (or is it dormant, perhaps for scaling)
 	processed bool									// has this instance run .Process()
 }
@@ -189,8 +187,6 @@ func (instance *Instance) Process() bool {
 
 	instance.Config = instance.Node.instanceConfig(instance.Name)
 	instance.HostConfig = instance.Node.instanceHostConfig(instance.Name)
-
-	instance.Containers = MatchContainers(instance.Node.client, instance.GetContainerName(), false)
 
 	instance.processed = true
 	return true

--- a/node.go
+++ b/node.go
@@ -26,6 +26,8 @@ type Node struct {
 
 	do map[string]bool 								// permissions list
 
+	Images []docker.APIImages
+
 	Config docker.Config							// docker client configuration for container
 	HostConfig docker.HostConfig			// docker client configuration for host
 
@@ -90,6 +92,8 @@ func (node *Node) Process(nodes Nodes) {
 	// scan the node for dependencies, and add them from the nodes
 	node.SetDependencies(nodes)
 
+	// @TODO I stopped this because it was making things really slow
+	//node.Images = MatchImages( node.client, node.GetImageName() )	
 }
 
 func (node *Node) GetImageName() string {

--- a/node.go
+++ b/node.go
@@ -26,8 +26,6 @@ type Node struct {
 
 	do map[string]bool 								// permissions list
 
-	Images []docker.APIImages
-
 	Config docker.Config							// docker client configuration for container
 	HostConfig docker.HostConfig			// docker client configuration for host
 
@@ -91,9 +89,6 @@ func (node *Node) Process(nodes Nodes) {
 
 	// scan the node for dependencies, and add them from the nodes
 	node.SetDependencies(nodes)
-
-	// @TODO I stopped this because it was making things really slow
-	//node.Images = MatchImages( node.client, node.GetImageName() )	
 }
 
 func (node *Node) GetImageName() string {

--- a/operation_info.go
+++ b/operation_info.go
@@ -45,7 +45,9 @@ func (node *Node) Info() bool {
 }
 
 func (node *Node) Info_Images() bool {
-	if len(node.Images)==0 {
+	images := node.GetImages()
+
+	if len(images)==0 {
 		node.log.Message("Node has no Images")
 	} else {
 		node.log.Message("Node Images")
@@ -66,7 +68,7 @@ func (node *Node) Info_Images() bool {
 		}
 		w.Write([]byte(strings.Join(row, "\t")+"\n"))
 
-		for index, image := range node.Images {
+		for index, image := range images {
 			row := []string{
 				strconv.FormatInt(int64(index+1), 10)+":",
 				image.ID[:11],
@@ -120,12 +122,14 @@ func (node *Node) Info_Instances() bool {
 			} else {
 				row = append(row, "no")
 			}
-			if len(instance.Containers) > 0 {
+
+			container, found := instance.GetContainer(false)
+			if found {
 				row = append(row,
-					instance.Containers[0].Status,
-					instance.Containers[0].ID[:12],
-					strconv.FormatInt(int64(instance.Containers[0].Created), 10),
-					strings.Join(instance.Containers[0].Names, ", "),
+					container.Status,
+					container.ID[:12],
+					strconv.FormatInt(int64(container.Created), 10),
+					strings.Join(container.Names, ", "),
 				)
 			} else {
 				row = append(row, "n/a")

--- a/operation_info.go
+++ b/operation_info.go
@@ -45,9 +45,7 @@ func (node *Node) Info() bool {
 }
 
 func (node *Node) Info_Images() bool {
-	images := node.GetImages()
-
-	if len(images)==0 {
+	if len(node.Images)==0 {
 		node.log.Message("Node has no Images")
 	} else {
 		node.log.Message("Node Images")
@@ -68,7 +66,7 @@ func (node *Node) Info_Images() bool {
 		}
 		w.Write([]byte(strings.Join(row, "\t")+"\n"))
 
-		for index, image := range images {
+		for index, image := range node.Images {
 			row := []string{
 				strconv.FormatInt(int64(index+1), 10)+":",
 				image.ID[:11],
@@ -111,9 +109,7 @@ func (node *Node) Info_Instances() bool {
 
 		instances := node.GetInstances(false)
 
-		for index, instance := range instances {
-			container, exists := instance.GetContainer(false)
-
+		for index, instance := range instances {			
 			row := []string{
 				strconv.FormatInt(int64(index+1), 10),
 				instance.Name,
@@ -124,12 +120,12 @@ func (node *Node) Info_Instances() bool {
 			} else {
 				row = append(row, "no")
 			}
-			if exists {
+			if len(instance.Containers) > 0 {
 				row = append(row,
-					container.Status,
-					container.ID[:12],
-					strconv.FormatInt(int64(container.Created), 10),
-					strings.Join(container.Names, ", "),
+					instance.Containers[0].Status,
+					instance.Containers[0].ID[:12],
+					strconv.FormatInt(int64(instance.Containers[0].Created), 10),
+					strings.Join(instance.Containers[0].Names, ", "),
 				)
 			} else {
 				row = append(row, "n/a")


### PR DESCRIPTION
This patch is an infrastructure patch that changes the initialization of nodes and instances so that they retrieve only when needed.
This infrastructure change is being used so that a scaling operation will be possible in the future. 

Originally this patch was to preload all images lists and containers, but that got really slow, and affected all operations, so a different approach was taken
