### PR TITLE
overhaul and added scale operation

### DIFF
--- a/client.go
+++ b/client.go
@@ -161,7 +161,7 @@ func MatchContainers(client *docker.Client, containerPrefix string, running bool
 	containers := []docker.APIContainers{}
 
 	for _, container := range cache.getContainers(false) {
-		if running && !strings.Contains(container.Status, "RUNNING") {
+		if running && !strings.Contains(container.Status, "Up") {
 			continue
 		}
 

--- a/dependency.go
+++ b/dependency.go
@@ -73,15 +73,15 @@ func (node *Node) DependencyInstanceMatches(targets []string, fallbackInstance s
 
 			if targetInstanceName=="%ALL" {
 				// in this case we have a meta request to link to all active instances of a target
-				targetInstances = targetNode.GetInstances(true)
+				targetInstances = targetNode.GetInstances()
 			} else if targetInstanceName=="%RANDOM" {
 				if randomTarget := targetNode.GetRandomInstance(true); randomTarget!=nil {
 					targetInstances = []*Instance{ randomTarget }
 				}
 			} else if targetNode.InstanceType=="single" && ( targetInstanceName=="" || targetInstanceName=="single" || fallbackInstance=="single" ) {
-				targetInstances = targetNode.FilterInstances([]string{"single"}, true)
+				targetInstances = targetNode.FilterInstances([]string{"single"})
 			} else {
-				targetInstances = targetNode.FilterInstances([]string{targetInstanceName, fallbackInstance}, true)
+				targetInstances = targetNode.FilterInstances([]string{targetInstanceName, fallbackInstance})
 			}
 
 			for _, target := range targetInstances {

--- a/operation.go
+++ b/operation.go
@@ -26,6 +26,9 @@ func GetOperation(name string, nodes Nodes, targets []string, conf *Conf, log Lo
 		case "up":
 			return Operation(&Operation_Up{log:log.ChildLog("UP"), nodes:nodes, targets:targets})
 
+		case "scale":
+			return Operation(&Operation_Scale{log:log.ChildLog("SCALE"), nodes:nodes, targets:targets})
+
 		case "create":
 			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), nodes:nodes, targets:targets})
 		case "remove":

--- a/operation_attach.go
+++ b/operation_attach.go
@@ -39,10 +39,12 @@ func (operation *Operation_Attach) Run() {
 }
 
 func (nodes *Nodes) Attach(targets []string) {
-	for _, target := range nodes.GetTargets(targets, true) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("start") {
 			for _, instance := range target.instances {
-				instance.Attach()
+				if instance.isActive() {
+					instance.Attach()
+				}
 			}
 		}
 	}
@@ -54,12 +56,12 @@ func (node *Node) Attach(filters []string) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(false)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, false)
+			instances = node.FilterInstances(filters)
 		}
 		for _, instance := range instances {
-			if instance.active {
+			if instance.isActive() {
 				instance.Attach()
 			}
 		}

--- a/operation_build.go
+++ b/operation_build.go
@@ -62,7 +62,7 @@ func (operation *Operation_Build) Run() {
 }
 
 func (nodes *Nodes) Build(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets, true) {
+	for _, target := range nodes.GetTargets(targets) {
 		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
 
 		// ignore target instances, and just build the node

--- a/operation_commit.go
+++ b/operation_commit.go
@@ -80,10 +80,12 @@ func (operation *Operation_Commit) Run() {
 }
 
 func (nodes *Nodes) Commit(targets []string, repo string, tag string, message string) {
-	for _, target := range nodes.GetTargets(targets,false) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("commit") {
 			for _, instance := range target.instances {
-				instance.Commit(repo, tag, message)
+				if instance.HasContainer(false) {
+					instance.Commit(repo, tag, message)
+				}
 			}
 		}
 	}
@@ -92,7 +94,7 @@ func (nodes *Nodes) Commit(targets []string, repo string, tag string, message st
 func (node *Node) Commit(repo string, instance string, tag string, message string) {
 	if node.Do("commit") {
 
-		for _, instance := range node.FilterInstances([]string{instance}, false) {
+		for _, instance := range node.FilterInstances([]string{instance}) {
 			if instance.HasContainer(false) {
 				instance.Commit(repo, tag, message)
 			}

--- a/operation_create.go
+++ b/operation_create.go
@@ -52,28 +52,41 @@ func (operation *Operation_Create) Run() {
 	operation.nodes.Create(operation.targets, operation.cmd, true, force)
 }
 
-func (nodes *Nodes) Create(targets []string, cmdOverride []string, onlyActive bool, force bool) {
-	for _, target := range nodes.GetTargets(targets, onlyActive) {
+func (nodes *Nodes) Create(targets []string, cmdOverride []string, onlyDefault bool, force bool) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("create") {
 			for _, instance := range target.instances {
+				if instance.HasContainer(false) {
+					continue
+				}
+				if onlyDefault && !instance.isDefault() {
+					continue
+				}
 				instance.Create(cmdOverride, force)
 			}
 		}
 	}
 }
 
-func (node *Node) Create(filters []string, onlyActive bool, force bool) {
+func (node *Node) Create(filters []string, cmdOverride []string, onlyDefault bool, force bool) {
 	if node.Do("create") {
 
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(onlyActive)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, onlyActive)
+			instances = node.FilterInstances(filters)
 		}
+
 		for _, instance := range instances {
-			instance.Create([]string{}, force)
+			if instance.HasContainer(false) {
+				continue
+			}
+			if onlyDefault && !instance.isDefault() {
+				continue
+			}
+			instance.Create(cmdOverride, force)
 		}
 
 	}

--- a/operation_destroy.go
+++ b/operation_destroy.go
@@ -55,7 +55,7 @@ func (operation *Operation_Destroy) Run() {
 }
 
 func (nodes *Nodes) Destroy(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets, true) {
+	for _, target := range nodes.GetTargets(targets) {
 		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
 		target.node.Destroy(force)
 	}

--- a/operation_info.go
+++ b/operation_info.go
@@ -43,7 +43,7 @@ func (operation *Operation_Info) Run() {
 }
 
 func (nodes *Nodes) Info(targets []string) {
-	for _, target := range nodes.GetTargets(targets, false) {
+	for _, target := range nodes.GetTargets(targets) {
 		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
 		target.node.Info()
 	}
@@ -115,6 +115,7 @@ func (node *Node) Info_Instances() bool {
 			"",
 			"Name",
 			"Container",
+			"Default",
 			"Active",
 			"Status",
 			"ID",
@@ -123,7 +124,7 @@ func (node *Node) Info_Instances() bool {
 		}
 		w.Write([]byte(strings.Join(row, "\t")+"\n"))
 
-		instances := node.GetInstances(false)
+		instances := node.GetInstances()
 
 		for index, instance := range instances {			
 			row := []string{
@@ -131,7 +132,12 @@ func (node *Node) Info_Instances() bool {
 				instance.Name,
 				instance.GetContainerName(),
 			}
-			if instance.active {
+			if instance.isDefault() {
+				row = append(row, "yes")
+			} else {
+				row = append(row, "no")
+			}
+			if instance.isActive() {
 				row = append(row, "yes")
 			} else {
 				row = append(row, "no")

--- a/operation_pause.go
+++ b/operation_pause.go
@@ -34,10 +34,12 @@ func (operation *Operation_Pause) Run() {
 }
 
 func (nodes *Nodes) Pause(targets []string) {
-	for _, target := range nodes.GetTargets(targets, true) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("start") {
 			for _, instance := range target.instances {
-				instance.Pause(false)
+				if instance.HasContainer(true) {
+					instance.Pause(false)
+				}
 			}
 		}
 	}
@@ -49,12 +51,13 @@ func (node *Node) Pause(filters []string, force bool) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(false)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, false)
+			instances = node.FilterInstances(filters)
 		}
+
 		for _, instance := range instances {
-			if instance.active {
+			if instance.HasContainer(true) {
 				instance.Pause(force)
 			}
 		}

--- a/operation_pull.go
+++ b/operation_pull.go
@@ -46,7 +46,7 @@ func (operation *Operation_Pull) Run() {
 }
 
 func (nodes *Nodes) Pull(targets []string, registry string) {
-	for _, target := range nodes.GetTargets(targets, false) {
+	for _, target := range nodes.GetTargets(targets) {
 		target.node.log = nodes.log.ChildLog("NODE:"+target.node.Name)
 		target.node.Pull(registry)
 	}

--- a/operation_remove.go
+++ b/operation_remove.go
@@ -52,10 +52,12 @@ func (operation *Operation_Remove) Run() {
 }
 
 func (nodes *Nodes) Remove(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets, !force) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("create") {
 			for _, instance := range target.instances {
-				instance.Remove(force)
+				if instance.HasContainer(false) {
+					instance.Remove(force)
+				}
 			}
 		}
 	}
@@ -67,12 +69,15 @@ func (node *Node) Remove(filters []string, force bool) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(true)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, true)
+			instances = node.FilterInstances(filters)
 		}
+
 		for _, instance := range instances {
-			instance.Remove(force)
+			if instance.HasContainer(false) {
+				instance.Remove(force)
+			}
 		}
 
 	}

--- a/operation_run.go
+++ b/operation_run.go
@@ -43,7 +43,7 @@ func (operation *Operation_Run) Run() {
 	operation.log.Message("running run operation")
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
-	for _, target := range operation.nodes.GetTargets(operation.targets, true) {
+	for _, target := range operation.nodes.GetTargets(operation.targets) {
 		target.node.log = operation.nodes.log.ChildLog("NODE:"+target.node.Name)
 		target.node.Run(operation.instance, operation.cmd)
 	}

--- a/operation_scale.go
+++ b/operation_scale.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+type Operation_Scale struct {
+	log Log
+
+	nodes Nodes
+	targets []string
+}
+func (operation *Operation_Scale) Flags(flags []string) {
+
+}
+
+func (operation *Operation_Scale) Help(topics []string) {
+	operation.log.Note(`Operation: CREATE
+
+Coach will attempt to scale up or down, the number of running instances on a scaled node
+
+Syntax:
+    $/> coach {targets} scale
+
+  {targets} what target node instances the operation should process ($/> coach help targets)
+
+Access:
+  - only scaled type nodes with the "start" access are processed.  This effectively limits it to service type nodes.
+`)
+}
+
+func (operation *Operation_Scale) Run() {
+	operation.log.Message("running scale operation")
+	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
+
+	TargetScaleReturn:
+	for _, target := range operation.nodes.GetTargets(operation.targets) {
+
+		InstanceScaleReturn:
+		for i := 0; i < len(target.node.InstanceMap); i++ {
+			if instance, ok := target.node.InstanceMap[strconv.FormatInt(int64(i+1), 10)]; ok {
+
+				container, hasContainer := instance.GetContainer(false)
+
+				if hasContainer {
+					if strings.Contains(container.Status, "Up") {
+						operation.log.Debug(LOG_SEVERITY_DEBUG_LOTS, "Node instance already has a running container :"+container.ID)
+						continue InstanceScaleReturn
+					}
+				} else {
+					// create a new container for this instance
+					instance.Create([]string{}, false)
+				}
+
+				operation.log.Message("Scaling up instance")
+				instance.Start(false)
+				continue TargetScaleReturn
+
+			}
+// operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "SCALE NODE TEST INSTANCE:", *target.node.InstanceMap[strconv.FormatInt(int64(i+1), 10)])
+		}
+
+		operation.log.Warning("Could not find any node instance to scale up to :"+target.node.Name)
+
+	}
+
+	cache.refresh(false, true)
+}

--- a/operation_start.go
+++ b/operation_start.go
@@ -32,10 +32,12 @@ func (operation *Operation_Start) Run() {
 }
 
 func (nodes *Nodes) Start(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets, !force) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("start") {
 			for _, instance := range target.instances {
-				instance.Start(force)
+				if instance.HasContainer(false) {
+					instance.Start(force)
+				}
 			}
 		}
 	}
@@ -47,12 +49,12 @@ func (node *Node) Start(filters []string, force bool) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(false)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, false)
+			instances = node.FilterInstances(filters)
 		}
 		for _, instance := range instances {
-			if instance.active {
+			if instance.HasContainer(false) {
 				instance.Start(force)
 			}
 		}

--- a/operation_stop.go
+++ b/operation_stop.go
@@ -34,10 +34,12 @@ func (operation *Operation_Stop) Run() {
 }
 
 func (nodes *Nodes) Stop(targets []string, force bool, timeout uint) {
-	for _, target := range nodes.GetTargets(targets, !force) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("start") {
 			for _, instance := range target.instances {
-				instance.Stop(force, timeout)
+				if instance.HasContainer(true) {
+					instance.Stop(force, timeout)
+				}
 			}
 		}
 	}
@@ -49,12 +51,13 @@ func (node *Node) Stop(filters []string, force bool, timeout uint) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(true)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, true)
+			instances = node.FilterInstances(filters)
 		}
+
 		for _, instance := range instances {
-			if instance.active {
+			if instance.HasContainer(true) {
 				instance.Stop(force, timeout)
 			}
 		}

--- a/operation_unpause.go
+++ b/operation_unpause.go
@@ -32,11 +32,15 @@ func (operation *Operation_Unpause) Run() {
 }
 
 func (nodes *Nodes) Unpause(targets []string, force bool) {
-	for _, target := range nodes.GetTargets(targets, !force) {
+	for _, target := range nodes.GetTargets(targets) {
 		if target.node.Do("start") {
+
 			for _, instance := range target.instances {
-				instance.Unpause(force)
+				if instance.HasContainer(true) {
+					instance.Unpause(force)
+				}
 			}
+
 		}
 	}
 }
@@ -47,12 +51,13 @@ func (node *Node) Unpause(filters []string, force bool) {
 		var instances []*Instance
 
 		if len(filters)==0 {
-			instances = node.GetInstances(false)
+			instances = node.GetInstances()
 		} else {
-			instances = node.FilterInstances(filters, false)
+			instances = node.FilterInstances(filters)
 		}
+
 		for _, instance := range instances {
-			if instance.active {
+			if instance.HasContainer(true) {
 				instance.Unpause(force)
 			}
 		}

--- a/operation_up.go
+++ b/operation_up.go
@@ -39,7 +39,7 @@ func (operation *Operation_Up) Run() {
 	operation.log.Message("running run operation")
 	operation.log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Targets:", operation.targets)
 
-	targets := operation.nodes.GetTargets(operation.targets, true)
+	targets := operation.nodes.GetTargets(operation.targets)
 
 	for _, target := range targets {
 		target.node.log = operation.nodes.log.ChildLog("NODE:"+target.node.Name)

--- a/targets.go
+++ b/targets.go
@@ -49,7 +49,7 @@ func targetStringSeparate(target string) (node string, instances []string) {
 	}
 }
 
-func (nodes Nodes) GetTargets(targetNames []string, onlyActive bool) []*Target {
+func (nodes Nodes) GetTargets(targetNames []string) []*Target {
 	log := nodes.log.ChildLog("TARGETS")
 
 	targets := []*Target{}				// ordered list of targets
@@ -71,9 +71,9 @@ func (nodes Nodes) GetTargets(targetNames []string, onlyActive bool) []*Target {
 							if node, ok := nodes.GetNode(name); ok {
 								_, instances := targetStringSeparate(target)
 								if len(instances)==0 {
-									targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+									targets = addNodeToTargets(targets, node, node.GetInstances())
 								} else {
-									targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
+									targets = addNodeToTargets(targets, node, node.FilterInstances(instances))
 								}
 							}
 						}
@@ -86,9 +86,9 @@ func (nodes Nodes) GetTargets(targetNames []string, onlyActive bool) []*Target {
 						if node, ok := nodes.GetNode(name); ok {
 							_, instances := targetStringSeparate(target)
 							if len(instances)==0 {
-								targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+								targets = addNodeToTargets(targets, node, node.GetInstances())
 							} else {
-								targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
+								targets = addNodeToTargets(targets, node, node.FilterInstances(instances))
 							}
 						}
 					}
@@ -101,9 +101,9 @@ func (nodes Nodes) GetTargets(targetNames []string, onlyActive bool) []*Target {
 				name, instances := targetStringSeparate(target)
 				if node, ok := nodes.GetNode(name); ok {
 					if len(instances)==0 {
-						targets = addNodeToTargets(targets, node, node.GetInstances(onlyActive))
+						targets = addNodeToTargets(targets, node, node.GetInstances())
 					} else {
-						targets = addNodeToTargets(targets, node, node.FilterInstances(instances, onlyActive))
+						targets = addNodeToTargets(targets, node, node.FilterInstances(instances))
 					}
 				} else {
 					nodes.log.Error("Unknown target passed: "+target)


### PR DESCRIPTION
The scale operation has been added.

To add it required overhauling what the "active" concept meant for instances.  The whole concept was overhauled, and now operations are targeting better options other than "is it active".

ISSUES: if you run an operation like start, but haven't created any containers, then you get no output (no instances are ready to be started.)  This will be mitigated with some changes to the message handling upcoming.
