### PR TITLE
Added tool operation

### DIFF
--- a/coach.go
+++ b/coach.go
@@ -74,7 +74,7 @@ func main() {
 	log.DebugObject(LOG_SEVERITY_DEBUG, "OPERATION: ["+operationName+"] => flags :", operationFlags)
 
 	// get an operation object
-	operation := GetOperation(operationName, nodes, targets, &conf, log.ChildLog("OPERATION"))
+	operation, _ := GetOperation(operationName, nodes, targets, &conf, log.ChildLog("OPERATION"))
 
 	log.DebugObject(LOG_SEVERITY_DEBUG_LOTS, "Operation", operation);
 

--- a/conf.go
+++ b/conf.go
@@ -44,7 +44,7 @@ func GetConf(log Log) Conf {
 }
 
 type DockerClientConf struct {
-	Host			string			`json:"Host,omitempty" yaml:"Host,omitempty"`
+	Host		string			`json:"Host,omitempty" yaml:"Host,omitempty"`
 	CertPath	string			`json:"CertPath,omitempty" yaml:"CertPath,omitempty"`
 }
 
@@ -135,12 +135,19 @@ func (conf *Conf) from_Default(includeEnv bool, log Log) {
 	conf.Paths["usercoach"] = path.Join(conf.Paths["userhome"],coachConfigFolder)
 	conf.Paths["usertemplates"] = path.Join(conf.Paths["usercoach"],"templates")
 	conf.Paths["usersecrets"] = path.Join(conf.Paths["usercoach"],"secrets")
-	conf.Paths["project"] = wd
+	conf.Paths["projectroot"] = wd
 	conf.Paths["projectcoach"] = path.Join(wd,coachConfigFolder)
 	conf.Paths["projectsecrets"] = path.Join(conf.Paths["projectcoach"],"secrets") // keep secret things in one place for gitignore
 	conf.Paths["build"] = conf.Paths["projectcoach"] // maybe for remote builds, this should be different?
 
-	// add all environment variables for the user to the env list
+	// add paths to the token list
+	// @TODO this is too early to perform this task, as the paths may change
+	for key, keyPath := range conf.Paths {
+		key = "PATH_"+strings.ToUpper(key)
+		conf.Tokens[key] = keyPath
+	}
+
+	// add all environment variables for the user to the token list
 	if includeEnv {
 		for _, env := range os.Environ() {
 			envsplit := strings.SplitN(env, "=", 2)
@@ -150,5 +157,4 @@ func (conf *Conf) from_Default(includeEnv bool, log Log) {
 			conf.Tokens[envsplit[0]] = envsplit[1]
 		}
 	}
-
 }

--- a/instance.go
+++ b/instance.go
@@ -224,7 +224,7 @@ func (node Node) instanceHostConfig(name string) docker.HostConfig {
 			} else if (binds[0][0:1]=="~") { // one would think that path can handle such terminology
 				binds[0] = path.Join(node.conf.Paths["userhome"], binds[0][1:])
 			} else {
-				binds[0] = path.Join(node.conf.Paths["project"], binds[0])
+				binds[0] = path.Join(node.conf.Paths["projectroot"], binds[0])
 			}
 			config.Binds[index] = strings.Join(binds, ":")
 		}

--- a/operation.go
+++ b/operation.go
@@ -1,61 +1,64 @@
 package main
 
-func GetOperation(name string, nodes Nodes, targets []string, conf *Conf, log Log) Operation {
+func GetOperation(name string, nodes Nodes, targets []string, conf *Conf, log Log) (Operation, bool) {
 
 	switch name {
 		case "help":
-			return Operation(&Operation_Help{log:log.ChildLog("HELP"), conf: conf, targets: targets})
+			return Operation(&Operation_Help{log:log.ChildLog("HELP"), conf: conf, targets: targets}), true
 
 		case "info":
-			return Operation(&Operation_Info{log:log.ChildLog("INFO"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Info{log:log.ChildLog("INFO"), nodes:nodes, targets:targets}), true
 		// case "status":
 
+		case "tool":
+			return Operation(&Operation_Tool{log:log.ChildLog("TOOL"), conf: conf, nodes:nodes, targets:targets}), true
+
 		case "init":
-			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, targets: targets})
+			return Operation(&Operation_Init{log:log.ChildLog("INIT"), conf: conf, targets: targets}), true
 
 		case "pull":
-			return Operation(&Operation_Pull{log:log.ChildLog("PULL"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Pull{log:log.ChildLog("PULL"), nodes:nodes, targets:targets}), true
 		case "build":
-			return Operation(&Operation_Build{log:log.ChildLog("BUILD"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Build{log:log.ChildLog("BUILD"), nodes:nodes, targets:targets}), true
 		case "destroy":
-			return Operation(&Operation_Destroy{log:log.ChildLog("DESTROY"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Destroy{log:log.ChildLog("DESTROY"), nodes:nodes, targets:targets}), true
 
 		case "run":
-			return Operation(&Operation_Run{log:log.ChildLog("RUN"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Run{log:log.ChildLog("RUN"), nodes:nodes, targets:targets}), true
 
 		case "up":
-			return Operation(&Operation_Up{log:log.ChildLog("UP"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Up{log:log.ChildLog("UP"), nodes:nodes, targets:targets}), true
 
 		case "scale":
-			return Operation(&Operation_Scale{log:log.ChildLog("SCALE"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Scale{log:log.ChildLog("SCALE"), nodes:nodes, targets:targets}), true
 
 		case "create":
-			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Create{log:log.ChildLog("CREATE"), nodes:nodes, targets:targets}), true
 		case "remove":
-			return Operation(&Operation_Remove{log:log.ChildLog("REMOVE"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Remove{log:log.ChildLog("REMOVE"), nodes:nodes, targets:targets}), true
 
 		case "start":
-			return Operation(&Operation_Start{log:log.ChildLog("START"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Start{log:log.ChildLog("START"), nodes:nodes, targets:targets}), true
 		case "stop":
-			return Operation(&Operation_Stop{log:log.ChildLog("STOP"), nodes:nodes, targets:targets, timeout: 3})
+			return Operation(&Operation_Stop{log:log.ChildLog("STOP"), nodes:nodes, targets:targets, timeout: 3}), true
 
 		case "attach":
-			return Operation(&Operation_Attach{log:log.ChildLog("ATTACH"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Attach{log:log.ChildLog("ATTACH"), nodes:nodes, targets:targets}), true
 
 		case "pause":
-			return Operation(&Operation_Pause{log:log.ChildLog("PAUSE"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Pause{log:log.ChildLog("PAUSE"), nodes:nodes, targets:targets}), true
 		case "unpause":
-			return Operation(&Operation_Unpause{log:log.ChildLog("UNPAUSE"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Unpause{log:log.ChildLog("UNPAUSE"), nodes:nodes, targets:targets}), true
 
 		case "commit":
-			return Operation(&Operation_Commit{log:log.ChildLog("COMMIT"), nodes:nodes, targets:targets})
+			return Operation(&Operation_Commit{log:log.ChildLog("COMMIT"), nodes:nodes, targets:targets}), true
 
 		default:
-			return Operation(&EmptyOperation{name: name, log: log.ChildLog("EMPTY")})
+			return Operation(&EmptyOperation{name: name, log: log.ChildLog("EMPTY")}), false
 	}
 
 
-	return nil
+	return nil, false
 }
 
 

--- a/operation_help.go
+++ b/operation_help.go
@@ -83,9 +83,13 @@ func (operation *Operation_Help) Run() {
 		case "operations":
 			operation.Topic_Operations(helpTopicFlags)
 
-		default: //assume this is an operation call
-			helpTopic := GetOperation(helpTopicName, operation.nodes , operation.targets, operation.conf, operation.log)
-			helpTopic.Help(helpTopicFlags)
+		default: 
+
+			//  test this is an operation call
+			if helpOperation, found := GetOperation(helpTopicName, operation.nodes , operation.targets, operation.conf, operation.log); found {
+				helpOperation.Help(helpTopicFlags)
+			}
+
 	}
 }
 

--- a/operation_tool.go
+++ b/operation_tool.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"path"
+	"io/ioutil"
+)
+
+type Operation_Tool struct {
+	log Log
+
+	conf *Conf
+
+	nodes Nodes
+	targets []string
+
+	flags []string
+
+	tool string
+	tools Tools
+}
+func (operation *Operation_Tool) Flags(flags []string) {
+	operation.tool = ""
+
+	// first flag is the tool name
+	if len(flags)>0 {
+		operation.tool = flags[0]
+		flags = flags[1:]
+	}
+
+	operation.flags = flags
+}
+
+func (operation *Operation_Tool) Help(topics []string) {
+	operation.log.Note(`Operation: Tool
+
+Coach will attempt to run an external tool, as listed in either the 
+project or user tool.yml file.  This conceptually allows a script to
+be run, with added ENV variables from the conf system, without having
+to worry about the path to the script.
+
+
+`)
+}
+
+func (operation *Operation_Tool) Run() {
+	if operation.tools==nil {
+		operation.tools = Tools{}
+	}
+
+	// load any user tools
+	operation.ToolsFromYaml("usercoach", true)
+	// load any project specific tools
+	operation.ToolsFromYaml("projectcoach", true)
+
+	if operation.tool=="" {
+		operation.log.Error("No tool specified")
+	} else if tool := operation.tools[operation.tool]; tool==nil {
+		operation.log.Error("Specified tool not found")
+	} else {
+		tool.Run(operation.flags)
+	}
+}
+
+
+func (operation *Operation_Tool) ToolsFromYaml(toolPathKey string, overwrite bool) bool {
+	operation.log.Debug(LOG_SEVERITY_DEBUG_LOTS,"Updating Conf from YAML")
+
+	if toolPath, ok := operation.conf.Path(toolPathKey); ok {
+		// get the path to where the config file should be
+		toolPath = path.Join(toolPath, "tools.yml")
+
+		operation.log.Debug(LOG_SEVERITY_DEBUG_WOAH,"coach tool file:"+toolPath)
+
+		// read the config file
+		yamlFile, err := ioutil.ReadFile(toolPath)
+		if err!=nil {
+			operation.log.Debug(LOG_SEVERITY_DEBUG_LOTS,"Could not read the YAML file ["+toolPath+"]: "+err.Error())
+			return false
+		}
+
+		// replace tokens in the yamlFile
+		yamlFile = []byte( operation.conf.TokenReplace(string(yamlFile)) )
+		operation.log.Debug(LOG_SEVERITY_DEBUG_STAAAP,"YAML (tokenized):"+ string(yamlFile))
+
+		operation.tools.GetToolsFromYaml(operation.conf, operation.log, yamlFile, overwrite)
+		return true
+	}
+	return false
+}

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"gopkg.in/yaml.v2"
+	"encoding/json"
+
+	"path"
+	"os"
+ 	"os/exec"	
+)
+
+// DB of Tools
+type Tools map[string]Tool
+
+func (tools Tools) GetToolsFromYaml(conf *Conf, log Log, source []byte, overwrite bool) {
+	var yaml_tools map[string]map[string]interface{}
+	err := yaml.Unmarshal(source, &yaml_tools)
+	if err!=nil {
+		return
+	}
+
+	for name, tool_struct := range yaml_tools {
+
+		switch (tool_struct["Type"]) {
+			case "script":
+				json_tool, _ := json.Marshal(tool_struct)
+				var tool Tool_Script
+				err := json.Unmarshal(json_tool, &tool)
+				if err!=nil {
+					continue
+				}
+
+				tool.conf = conf
+				tool.log = log
+
+				if exists:=tools[name]; exists==nil || overwrite {
+					tools[name] = Tool(&tool)
+				}
+		}
+
+	}
+}
+
+// Defining Tool interface
+type Tool interface {
+	Run(flags []string) bool
+}
+
+// Script type tool
+type Tool_Script struct {
+	conf *Conf
+	log Log
+
+	Script []string		`json:"Script,omitempty" yaml:"Script,omitempty"`
+	Env []string		`json:"ENV,omitempty" yaml:"ENV,omitempty"`
+
+	EnvIsolate bool     `json:"EnvIsolate,omitempty" yaml:"EnvIsolate,omitempty"`
+	LeavePathAlone bool `json:"LeavePathAlone,omitempty" yaml:"LeavePathAlone,omitempty"`
+}
+func (tool *Tool_Script) Run(flags []string) bool {
+
+tool.log.DebugObject( LOG_SEVERITY_MESSAGE, "TOOL SCRIPT", tool.Script)
+
+// tool.Script = []string{"ps", "-aux"}
+
+	cmd_first := tool.Script[0]
+	args := []string{}
+	if len(tool.Script)>1 {
+		args = tool.Script[1:]
+	}
+
+	if path.IsAbs(cmd_first) {
+
+	} else if cmd_first[0:1]=="~" { // one would think that path can handle such terminology
+		cmd_first = path.Join(tool.conf.Paths["userhome"], cmd_first[1:])
+	} else {
+		cmd_first = path.Join(tool.conf.Paths["project"], cmd_first)
+	}
+
+	cmd := exec.Command( cmd_first, args... )
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = tool.log
+	cmd.Stderr = tool.log
+
+	if len(tool.Env)>0 {
+		if !tool.EnvIsolate {
+			cmd.Env = append(cmd.Env, os.Environ()...)
+		}
+
+		cmd.Env = append(cmd.Env, tool.Env...) 
+	}
+
+	tool.log.Message("Running Script")
+	err := cmd.Start()
+
+	if err!=nil {
+		tool.log.Error("SCRIPT FAILED => "+err.Error())
+		return false
+	}
+
+	tool.log.Message("SCRIPT RUN")
+	err = cmd.Wait()
+	return err==nil
+}


### PR DESCRIPTION
You can now define tools at the user and project level, which can be run using the coach command.  The most typical (and only implemented) tool case is to run a script.

This allows the following advantages:
- run the script from anywhere inside the project path (as any coach operation can do) so no worrying about being in the right folder;
- use tokens from coach as ENV variables in script, to configure the script using the same settings as coach uses

@NOTE the following changes were also made:
- refactored operations a bit (if an operation is not found a boolean false is returned along with the empty operation),
- added paths to tokens
