### PR TITLE
New demo inits

### DIFF
--- a/init.go
+++ b/init.go
@@ -303,7 +303,6 @@ func (task *InitTaskMessage) RunTask(log Log) bool {
  * Getting tasks from YAML
  */
 
-
 func (tasks *InitTasks) AddTasksFromYaml(yamlSource []byte) error {
 
   var yaml_tasks []map[string]interface{}
@@ -354,9 +353,6 @@ func (tasks *InitTasks) AddTasksFromYaml(yamlSource []byte) error {
           taskAdder = TaskAdder(&task)
         }
     }
-
-
-tasks.log.DebugObject(LOG_SEVERITY_ERROR, "INIT TASK:", task_struct["Type"], task_struct)
 
     if taskAdder!=nil {
       taskAdder.AddTask(tasks)

--- a/operation_init.go
+++ b/operation_init.go
@@ -14,10 +14,10 @@ import (
 var (
  	// coach demos are keyed remoteyamls
 	COACH_DEMO_URLS = map[string]string{
-	  "lamp": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp/.coach/coachinit.yml",
-	  "lamp_monolithic": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_monolithic/.coach/coachinit.yml",
-	  "lamp_multiplephps": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_multiplephps/.coach/coachinit.yml",
-	  "lamp_scaling": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_scaling/.coach/coachinit.yml",
+	  "lamp": "https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/lamp/.coach/coachinit.yml",
+	  "lamp_monolithic": "https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/lamp_monolithic/.coach/coachinit.yml",
+	  "lamp_multiplephps": "https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/lamp_multiplephps/.coach/coachinit.yml",
+	  "lamp_scaling": "https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/lamp_scaling/.coach/coachinit.yml",
   }
 )
 

--- a/operation_init.go
+++ b/operation_init.go
@@ -14,10 +14,7 @@ import (
 var (
  	// coach demos are keyed remoteyamls
 	COACH_DEMO_URLS = map[string]string{
-	  "wunder": "https://github.com/james-nesbitt/coach/blob/master/coach.go",
-	  "lamp": "https://github.com/james-nesbitt/coach/blob/master/coach.go",
-	  "lamp-drupal8composer": "https://github.com/james-nesbitt/coach/blob/master/coach.go",
-	  "lamp-platformsh": "https://github.com/james-nesbitt/coach/blob/master/coach.go",
+	  "lamp": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp/.coach/coachinit.yml",
   }
 )
 
@@ -282,7 +279,6 @@ func (operation *Operation_Init) Init_RemoteYaml_Run(url string, tasks *InitTask
   }
   defer resp.Body.Close()
   yamlSourceBytes, err := ioutil.ReadAll(resp.Body)
-
 
   tasks.AddMessage("Initializing using Remote YAML Source ["+url+"] to local project folder")
 

--- a/operation_init.go
+++ b/operation_init.go
@@ -15,6 +15,9 @@ var (
  	// coach demos are keyed remoteyamls
 	COACH_DEMO_URLS = map[string]string{
 	  "lamp": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp/.coach/coachinit.yml",
+	  "lamp_monolithic": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_monolithic/.coach/coachinit.yml",
+	  "lamp_multiplephps": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_multiplephps/.coach/coachinit.yml",
+	  "lamp_scaling": "https://raw.githubusercontent.com/james-nesbitt/coach/demoinits/templates/demo/lamp_scaling/.coach/coachinit.yml",
   }
 )
 
@@ -126,16 +129,43 @@ EXAMPLES:
     Populate the current path with default settings
 
     $/> coach init user {template}
+
     Uses the contents of ~/.coach/templates to populate the current folder
 
     $/> coach init git https://github.com/aleksijohansson/docker-drupal-coach.git
+
     Clones the target git URL to the current path
 
     There are also various demo inits:
       $/> coach init demo lamp
-      $/> coach init demo scale
-      $/> coach init demo wunder
 
+      	creates a standard LAMP stack
+
+      $/> coach init demo lamp_monolithic
+
+        creates a single container LAMP stack
+
+      $/> coach init demo lamp_multiplephps
+
+        creates a LAMP stack with multiple php servers to
+
+      $/> coach init demo lamp_scaling
+
+YAML base inits
+
+There is is a YAML file syntax that can be used to define an init,
+which describes a set of operations such as creating fields etc. The 
+demo inits are based on this forumla, and can be seen on the git repo
+for the coach project.
+
+If you have a fileset that you like, then convert it to the YAML syntax
+and keep it on the internet, either in a repo, or a gist or even a pastebin.
+
+Then you can create a new project using :
+  
+    $/> coach init remoteyaml http://path.to.my/yaml.yml
+
+    (note that the path has to be a full body yml file)
 `)
 }
 

--- a/operation_init_default.go
+++ b/operation_init_default.go
@@ -100,11 +100,20 @@ Docker:  # Override Docker configuration
 #
 PERSONAL_APP_KEY: APP_KEY_VALUE
 `)
-  tasks.AddFile(".coach/nodes.yml",  `# Project nodes
+  tasks.AddFile(".coach/nodes.yml",  `###
+# Project nodes
 #
 # A string map of node configurations, each entry is a node, which 
 # corresponds to a set of containers based on a single image.  the
 # nodes have different types, an different purposes:
+#
+# Nodes: 
+#   Each element in the yml file is a keyed configuration to configure
+#   a single coach node, which is any number of docker containers
+#   that use a single build/image.  The nodes can be just used to 
+#   build images, or can be used to store data, run services or run
+#   commands.  A node can use multiple containers to provide scaling
+#   services, or alternate services.
 #
 # Types:
 #   - build: only used for building images, let's you build a base 

--- a/templates/demo/lamp/.coach/coachinit.yml
+++ b/templates/demo/lamp/.coach/coachinit.yml
@@ -1,0 +1,421 @@
+- Type: File
+  Path: README.md
+  Contents: |
+    # COACH DEMO: Standard Lamp
+
+    This coach demo provides a standard LAMP stack:
+
+    - Nginx service using jamesnesbitt/wunder-nginx
+    - PHP-FPM service using jamesnesbitt/wunder-php56fpm
+    - DB service using jamesnesbitt/wunder-mariadb
+
+    To incorporate source, the source code from /app/source
+    is mapped into a "source" container, which is used in
+    the nginx and fpm containers.
+
+    The Database is un-initialized, but an optional init
+    build for a db has been included, and you can switch to
+    it by removing the db node, and uncommenting the custom
+    db node.
+
+    All of the suggested images in this project are based on
+    the wunder-base concept, which is used to provide a commong
+    /app project folder, and similar users/OS, to keep access
+    privileges working better.
+    The builds are all CentOS7, EPEL and often REMI based builds.
+
+    # Getting Started:
+
+      You already did this:
+
+        #/> coach init demo lampstack
+
+      Now just do this:
+
+        $/> coach up
+
+      This should:
+
+        - download some images
+        - build any local images that were defined
+        - create a source container which will map ./app/source to /app/www/active
+
+        - start an nginx container, and fpm container and a db container
+
+      You should then have
+
+        - http access at host:8080, or directly on the container
+        - the http should point to the source code in /app/source
+
+    # Day to day use
+
+    ## starting and stopping
+
+        $/> coach stop
+        $/> coach start
+
+    ## starting a specific container
+
+      - start a specific node
+
+        $/> coach @www start
+
+      - start all service nodes
+
+        $/> coach %service start
+
+    ## rebuild any containers
+
+      1. stop any running containers
+
+        $/> coach stop
+
+      2. remove and created containers
+
+        $/> coach remove
+
+      3. recreate and containers
+
+        $/> coach create 
+
+      4. start the new containers 
+
+        $/> coach start
+
+    # Alterations that you should make
+
+    ## Custom DB
+
+    The nodes.yml file has a better DB image commented out which you could use to get
+    a DB container that has an already populated DB with specific access credentials.
+
+    ## Switch to PHP7 or HHVM
+
+    If you want to test out the latest PHP7 or HHVM builds, try changing nodes.yml, the 
+    fpm node Image values.  There are instructions above the node.
+
+    Note that if you want to swap out fpm containers, you will need to stop and remove
+    both the fpm and nginx nodes, alter the nodes yml, and then start www and fpm again
+    (you do not need to stop the db container.)
+
+    Instructions:
+
+    1. Make changes to your nodes.yml (change the fpm image)
+
+    2. stop www and fpm
+
+      $/> coach @fpm @www stop
+
+    3. remove www and fpm containers
+
+      $/> coach @fpm @www remove
+
+    4. make sure that you have all needed images
+     
+      $/> coach pull
+      $/> coach build
+
+    5. re-create www and fpm containers
+
+      $/> coach @fpm @www recreate
+
+    6. restart www and fpm containers
+
+      $/> coach @fpm @www start
+
+
+- Type: File
+  Path: .coach/conf.yml
+  Contents: |
+    # Coach project conf
+    #
+    # Configurations for the coach project
+    #
+    # Project: project name, used to create container names
+    # Author: used for docker commits & pushes.
+    #   @note this needs to be valid for container names/images
+    #     so it can contain alpha-numeric & "_"
+    #
+    # Tokens: a string map for string substitutions elsewhere
+    #    by using the format %{key} in files loaded after this
+    #    one
+    #
+    # Paths: a string map of paths that you can use for 
+    #    things like docker builds and mounts.  Paths can be 
+    #    absolute or relative to the project root.
+    #    Note that you can override the following paths:
+    #      - usertemplates : path to users init templates
+    #      - usersecrets : path to user secrets
+    #      - projectsecrets : path to project secrets
+    #      - build : path to builds
+    #    Paths are also made available as tokens using the
+    #    format PATH_{UPPERCASEKEY}
+    #
+
+    # Project name
+    Project: lamp
+
+    Author: me
+
+    # Custom Tokens
+    Tokens:
+      # Set a container domain, which containers can pull in as ENV or box domains
+      CONTAINER_DOMAIN: demo.coach
+
+- Type: File
+  Path: .coach/nodes.yml
+  Contents: |
+    ###
+    # Project nodes
+    #
+    # A string map of node configurations, each entry is a node, which 
+    # corresponds to a set of containers based on a single image.  the
+    # nodes have different types, an different purposes:
+    #
+    # Nodes: 
+    #   Each element in the yml file is a keyed configuration to configure
+    #   a single coach node, which is any number of docker containers
+    #   that use a single build/image.  The nodes can be just used to 
+    #   build images, or can be used to store data, run services or run
+    #   commands.  A node can use multiple containers to provide scaling
+    #   services, or alternate services.
+    #
+    # Types:
+    #   - build: only used for building images, let's you build a base 
+    #        image for other nodes
+    #   - volume: non-running containers meant to hold files that are 
+    #        shared with other nodes
+    #   - service: a node with containers that get started and stopped
+    #   - command: a node that uses disposable containers to run commands
+    #        inside an environment
+    #
+    # Instances:
+    #   Nodes can have multiple containers called instances. The instances
+    #   setting tells coach how to treat the node instances:
+    #   - scale: allow numeric instances, and allow the scale operation 
+    #        to spin up new instanes.
+    #   - fixed: if you provide a string list of instances, then they 
+    #         can be started and stopped by name.
+    #   - temporary: instances started are removed when stopped.  For example
+    #         command containers are considered temporary.
+    #
+    #   Multiple instances are complex, especially when it comes to linking
+    #   Nodes together.  If one node is linked to another, either by Link,
+    #   or VolumesFrom, then coach tries to link matching instance names
+    #   possible (or you can user node:all to link to all)
+    #
+    # Tokens:
+    #
+    #  Tokens can be used for string substitution in this file.  Tokens can come
+    #  from the conf.yml, or from the secrets.yml (or from the users secrets.)
+    #  Tokens are substituted using a "%" prefix, before the YML is parsed, so
+    #  you may need to wrap tokenized settings in "quotes" when using them.
+    #
+    #  The following tokens are available:
+    #
+    #    - anything from the tokens section of the conf.yml
+    #    - anything from the project or user secrets.yml
+    #    
+    #    - the project name is accessible using %PROJECT
+    #    - any path value is accessible using %PATH_UPPERCASEPATHKEY
+    #    - multi-instance nodes can access the intance name as %INSTANCE
+    #
+    # Coach configuration:
+    #
+    #   - Type: You can define the node type (or it will default to service)
+    #   - Build: You can assign a Build path, which will be used to build a local
+    #        image for the node.  If you also define an image then that
+    #        is used for the image name.  If the path is relative, then it
+    #        is considered relative inside the .coach/ folder.
+    #   - Instances: a string list of instance names, or the keyword temporary
+    #        or the keyword scaled, followed by the integer values for initial
+    #        and maximum number of running containers
+    #        e.g.:
+    #           Instances: first second third
+    #           Instances: temporary
+    #           Instances: scaled 3 9
+    #
+    # Docker remote API Configurations:
+    #
+    #   The two principle parts of the configuration for a node are the 
+    #   Config and Host settings.
+    #   These wrap the client config and can use any of it's keys, which 
+    #   gives access to pretty much all of the docker remote API settings.
+    #
+    #   - Config : the dockerclient config element used define the internals
+    #        of a container.  
+    #        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L200
+    #   - Host : the dockerclient config element used to define the relationship
+    #        between the container and it's host.
+    #        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L472
+    #
+    ###
+
+    ###
+    # A volume container to hold source
+    #
+    # Using a conmtainer to hold source, even if it just locally binded source, is
+    # a good idea, because it replicates what a production service would do.  It would
+    # have source copied/exported/retrieved in, and make it available in the same way
+    #
+    source:
+      Type: volume
+
+      Config:
+        Image: jamesnesbitt/wunder-base # RUn from a standard base image
+      Host:
+        Binds:
+          - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+
+    ###
+    # Database service
+    #
+    # This container is a base DB image with no existing DB, nor access.  Consider 
+    # using a local build, to extend a base DB image, adding in a db, adding a user
+    # and setting exactly what access credentials that you want
+    #
+    db:
+      Type: service
+
+      Config:
+        Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+
+    ###
+    # Alternative Custom Database service
+    #
+    # This container uses a local build to extend a base db, adding in a database "app" and changing
+    # the root user password
+    # 
+    # @see ./coach/docker/db/Dockerfile
+    #
+    # This node needs building !  $/> coach build
+    #
+
+    # db:
+    #   Type: service
+    #   Build: /docker/db          # DB has a docker build so that we can create databases and set custom passwords.
+    #
+    #   Config:
+    #     RestartPolicy: on-failure
+    #     OpenStdin: true
+
+    ###
+    # FPM service
+    #
+    # This node implements a standard PHP-FPM service, which you can connect to over
+    # TCP/IP.  The node has access to the source via the source container, and the db
+    # using a docker link (accessible over TCP/IP at db.app)
+    #
+    # There are alternative PHP images that you could try, to test out HHVM or PHP7
+    # But note that if you switch, you have to recreate the container.
+    #
+    # Note that the WWW node needs this container
+    #
+    fpm:
+      Type: service
+
+      Config:
+        #Image: jamesnesbitt/wunder-hhvm      # The HHVM works
+        Image: jamesnesbitt/wunder-php56fpm     # The FPM works, and should have blackfire working
+        #Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+      Host:
+        Links:
+          - db:db.app # make the db container available as db.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
+    ###
+    # WWW service
+    #
+    # An nginx service, that handles http requests, and passes PHP parsing off to 
+    # the fpm node.  This node has some custom configurations to try to get it
+    # to respond to different URLs appropriately
+    #
+    # @note that this container binds to the host port for 8080, but can still be 
+    #   resolved by pointing to port 80 on the container IP
+    # @note that if you are using DNSDOCK, the DNSDOCK_ALIAS will help you browser to the service
+    # @note https is an option if you set up the image properly.
+    #
+    www:
+      Type: service
+
+      Config:
+        Image: jamesnesbitt/wunder-nginx  # recent nginx build using nginx provided centos repo
+        Hostname: "%PROJECT" # Token derived from the project name in conf.yml
+        Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+        Env:
+          - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+        ExposedPorts:
+          80/tcp: {}
+
+      Host:
+        Links:
+          - fpm:fpm.app # make the fpm service available as fpm.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
+        PortBindings:
+          80/tcp:
+            - HostPort: 8080 # Port 80 applies to all Host IPs
+
+- Type: File
+  Path: app/README.md
+  Contents: |
+    # Bare Project
+    ## /.coach/
+
+      Project coach configuration
+
+    ## /app
+
+      Project source-code and assets path
+
+- Type: File
+  Path: app/source/index.php
+  Contents: |
+    <?php
+    /**
+     * Put your PHP source code here
+     *
+     * Not that in this demo project, only this folder gets mapped into
+     * the source container, so relative includes that point above will
+     * fail.  You can change the source node bind as needed.
+     */
+
+    phpinfo();
+
+- Type: File
+  Path: .coach/docker/db/README.md
+  Contents: |
+    # DB Docker Build
+
+    This is a Docker build that can optionally be used for building a custom Database
+    image for the local project.
+
+    To use this build, add "docker/db" (the path inside the .coach folder) to an node,
+    and then you can use "$/> docker build" to build all node images
+
+- Type: File
+  Path: .coach/docker/db/Dockerfile
+  Contents: |
+    FROM        jamesnesbitt/wunder-mariadb
+    MAINTAINER  james.nesbitt@wunderkraut.com
+
+    ### ProjectDB --------------------------------------------------------------------
+
+
+    # Create our project DB
+    #
+    # - set the root user password to something safe (considered a good idea)
+    # - create an "app" database
+    # - give access to the new database to an "app" user using the password "app"
+    # - app user can only access from 172.* IPs !!!! (inside the docker subnet)
+    # - flush access
+    #
+    RUN (/usr/bin/mysqld_safe &) && sleep 5 && \
+        mysql -uroot -e "UPDATE mysql.user SET Password=PASSWORD('H4x0r') WHERE User='root'" && \
+        mysql -uroot -e "CREATE DATABASE app" && \
+        mysql -uroot -e "GRANT ALL ON app.* to app@'172.%' IDENTIFIED BY 'app'" && \
+        mysql -uroot -e "FLUSH PRIVILEGES"
+
+    ### /ProjectDB -------------------------------------------------------------------
+

--- a/templates/demo/lamp/.coach/coachinit.yml
+++ b/templates/demo/lamp/.coach/coachinit.yml
@@ -76,9 +76,9 @@
 
       3. recreate and containers
 
-        $/> coach create 
+        $/> coach create
 
-      4. start the new containers 
+      4. start the new containers
 
         $/> coach start
 
@@ -91,7 +91,7 @@
 
     ## Switch to PHP7 or HHVM
 
-    If you want to test out the latest PHP7 or HHVM builds, try changing nodes.yml, the 
+    If you want to test out the latest PHP7 or HHVM builds, try changing nodes.yml, the
     fpm node Image values.  There are instructions above the node.
 
     Note that if you want to swap out fpm containers, you will need to stop and remove
@@ -111,7 +111,7 @@
       $/> coach @fpm @www remove
 
     4. make sure that you have all needed images
-     
+
       $/> coach pull
       $/> coach build
 
@@ -418,4 +418,3 @@
         mysql -uroot -e "FLUSH PRIVILEGES"
 
     ### /ProjectDB -------------------------------------------------------------------
-

--- a/templates/demo/lamp/.coach/conf.yml
+++ b/templates/demo/lamp/.coach/conf.yml
@@ -1,0 +1,34 @@
+# Coach project conf
+#
+# Configurations for the coach project
+#
+# Project: project name, used to create container names
+# Author: used for docker commits & pushes.
+#   @note this needs to be valid for container names/images
+#     so it can contain alpha-numeric & "_"
+#
+# Tokens: a string map for string substitutions elsewhere
+#    by using the format %{key} in files loaded after this
+#    one
+#
+# Paths: a string map of paths that you can use for 
+#    things like docker builds and mounts.  Paths can be 
+#    absolute or relative to the project root.
+#    Note that you can override the following paths:
+#      - usertemplates : path to users init templates
+#      - usersecrets : path to user secrets
+#      - projectsecrets : path to project secrets
+#      - build : path to builds
+#    Paths are also made available as tokens using the
+#    format PATH_{UPPERCASEKEY}
+#
+
+# Project name
+Project: lamp
+
+Author: me
+
+# Custom Tokens
+Tokens:
+  # Set a container domain, which containers can pull in as ENV or box domains
+  CONTAINER_DOMAIN: demo.coach

--- a/templates/demo/lamp/.coach/docker/db/Dockerfile
+++ b/templates/demo/lamp/.coach/docker/db/Dockerfile
@@ -1,0 +1,21 @@
+FROM        jamesnesbitt/wunder-mariadb
+MAINTAINER  james.nesbitt@wunderkraut.com
+
+### ProjectDB --------------------------------------------------------------------
+
+
+# Create our project DB
+#
+# - set the root user password to something safe (considered a good idea)
+# - create an "app" database
+# - give access to the new database to an "app" user using the password "app"
+# - app user can only access from 172.* IPs !!!! (inside the docker subnet)
+# - flush access
+#
+RUN (/usr/bin/mysqld_safe &) && sleep 5 && \
+    mysql -uroot -e "UPDATE mysql.user SET Password=PASSWORD('H4x0r') WHERE User='root'" && \
+    mysql -uroot -e "CREATE DATABASE app" && \
+    mysql -uroot -e "GRANT ALL ON app.* to app@'172.%' IDENTIFIED BY 'app'" && \
+    mysql -uroot -e "FLUSH PRIVILEGES"
+
+### /ProjectDB -------------------------------------------------------------------

--- a/templates/demo/lamp/.coach/docker/db/README.md
+++ b/templates/demo/lamp/.coach/docker/db/README.md
@@ -1,0 +1,7 @@
+# DB Docker Build
+
+This is a Docker build that can optionally be used for building a custom Database
+image for the local project.
+
+To use this build, add "docker/db" (the path inside the .coach folder) to an node,
+and then you can use "$/> docker build" to build all node images

--- a/templates/demo/lamp/.coach/nodes.yml
+++ b/templates/demo/lamp/.coach/nodes.yml
@@ -1,0 +1,191 @@
+###
+# Project nodes
+#
+# A string map of node configurations, each entry is a node, which 
+# corresponds to a set of containers based on a single image.  the
+# nodes have different types, an different purposes:
+#
+# Nodes: 
+#   Each element in the yml file is a keyed configuration to configure
+#   a single coach node, which is any number of docker containers
+#   that use a single build/image.  The nodes can be just used to 
+#   build images, or can be used to store data, run services or run
+#   commands.  A node can use multiple containers to provide scaling
+#   services, or alternate services.
+#
+# Types:
+#   - build: only used for building images, let's you build a base 
+#        image for other nodes
+#   - volume: non-running containers meant to hold files that are 
+#        shared with other nodes
+#   - service: a node with containers that get started and stopped
+#   - command: a node that uses disposable containers to run commands
+#        inside an environment
+#
+# Instances:
+#   Nodes can have multiple containers called instances. The instances
+#   setting tells coach how to treat the node instances:
+#   - scale: allow numeric instances, and allow the scale operation 
+#        to spin up new instanes.
+#   - fixed: if you provide a string list of instances, then they 
+#         can be started and stopped by name.
+#   - temporary: instances started are removed when stopped.  For example
+#         command containers are considered temporary.
+#
+#   Multiple instances are complex, especially when it comes to linking
+#   Nodes together.  If one node is linked to another, either by Link,
+#   or VolumesFrom, then coach tries to link matching instance names
+#   possible (or you can user node:all to link to all)
+#
+# Tokens:
+#
+#  Tokens can be used for string substitution in this file.  Tokens can come
+#  from the conf.yml, or from the secrets.yml (or from the users secrets.)
+#  Tokens are substituted using a "%" prefix, before the YML is parsed, so
+#  you may need to wrap tokenized settings in "quotes" when using them.
+#
+#  The following tokens are available:
+#
+#    - anything from the tokens section of the conf.yml
+#    - anything from the project or user secrets.yml
+#    
+#    - the project name is accessible using %PROJECT
+#    - any path value is accessible using %PATH_UPPERCASEPATHKEY
+#    - multi-instance nodes can access the intance name as %INSTANCE
+#
+# Coach configuration:
+#
+#   - Type: You can define the node type (or it will default to service)
+#   - Build: You can assign a Build path, which will be used to build a local
+#        image for the node.  If you also define an image then that
+#        is used for the image name.  If the path is relative, then it
+#        is considered relative inside the .coach/ folder.
+#   - Instances: a string list of instance names, or the keyword temporary
+#        or the keyword scaled, followed by the integer values for initial
+#        and maximum number of running containers
+#        e.g.:
+#           Instances: first second third
+#           Instances: temporary
+#           Instances: scaled 3 9
+#
+# Docker remote API Configurations:
+#
+#   The two principle parts of the configuration for a node are the 
+#   Config and Host settings.
+#   These wrap the client config and can use any of it's keys, which 
+#   gives access to pretty much all of the docker remote API settings.
+#
+#   - Config : the dockerclient config element used define the internals
+#        of a container.  
+#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L200
+#   - Host : the dockerclient config element used to define the relationship
+#        between the container and it's host.
+#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L472
+#
+###
+
+###
+# A volume container to hold source
+#
+# Using a conmtainer to hold source, even if it just locally binded source, is
+# a good idea, because it replicates what a production service would do.  It would
+# have source copied/exported/retrieved in, and make it available in the same way
+#
+source:
+  Type: volume
+
+  Config:
+    Image: jamesnesbitt/wunder-base # RUn from a standard base image
+  Host:
+    Binds:
+      - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+
+###
+# Database service
+#
+# This container is a base DB image with no existing DB, nor access.  Consider 
+# using a local build, to extend a base DB image, adding in a db, adding a user
+# and setting exactly what access credentials that you want
+#
+db:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+
+###
+# Alternative Custom Database service
+#
+# This container uses a local build to extend a base db, adding in a database "app" and changing
+# the root user password
+# 
+# @see ./coach/docker/db/Dockerfile
+#
+# This node needs building !  $/> coach build
+#
+
+# db:
+#   Type: service
+#   Build: /docker/db          # DB has a docker build so that we can create databases and set custom passwords.
+#
+#   Config:
+#     RestartPolicy: on-failure
+#     OpenStdin: true
+
+###
+# FPM service
+#
+# This node implements a standard PHP-FPM service, which you can connect to over
+# TCP/IP.  The node has access to the source via the source container, and the db
+# using a docker link (accessible over TCP/IP at db.app)
+#
+# There are alternative PHP images that you could try, to test out HHVM or PHP7
+# But note that if you switch, you have to recreate the container.
+#
+# Note that the WWW node needs this container
+#
+fpm:
+  Type: service
+
+  Config:
+    #Image: jamesnesbitt/wunder-hhvm      # The HHVM works
+    Image: jamesnesbitt/wunder-php56fpm     # The FPM works, and should have blackfire working
+    #Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+###
+# WWW service
+#
+# An nginx service, that handles http requests, and passes PHP parsing off to 
+# the fpm node.  This node has some custom configurations to try to get it
+# to respond to different URLs appropriately
+#
+# @note that this container binds to the host port for 8080, but can still be 
+#   resolved by pointing to port 80 on the container IP
+# @note that if you are using DNSDOCK, the DNSDOCK_ALIAS will help you browser to the service
+# @note https is an option if you set up the image properly.
+#
+www:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-nginx  # recent nginx build using nginx provided centos repo
+    Hostname: "%PROJECT" # Token derived from the project name in conf.yml
+    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+    Env:
+      - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+    ExposedPorts:
+      80/tcp: {}
+
+  Host:
+    Links:
+      - fpm:fpm.app # make the fpm service available as fpm.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+    PortBindings:
+      80/tcp:
+        - HostPort: 8080 # Port 80 applies to all Host IPs

--- a/templates/demo/lamp/README.md
+++ b/templates/demo/lamp/README.md
@@ -1,0 +1,121 @@
+# COACH DEMO: Standard Lamp
+
+This coach demo provides a standard LAMP stack:
+
+- Nginx service using jamesnesbitt/wunder-nginx
+- PHP-FPM service using jamesnesbitt/wunder-php56fpm
+- DB service using jamesnesbitt/wunder-mariadb
+
+To incorporate source, the source code from /app/source
+is mapped into a "source" container, which is used in
+the nginx and fpm containers.
+
+The Database is un-initialized, but an optional init
+build for a db has been included, and you can switch to
+it by removing the db node, and uncommenting the custom
+db node.
+
+All of the suggested images in this project are based on
+the wunder-base concept, which is used to provide a commong
+/app project folder, and similar users/OS, to keep access
+privileges working better.
+The builds are all CentOS7, EPEL and often REMI based builds.
+
+# Getting Started:
+
+  You already did this:
+
+    #/> coach init demo lampstack
+
+  Now just do this:
+
+    $/> coach up
+
+  This should:
+
+    - download some images
+    - build any local images that were defined
+    - create a source container which will map ./app/source to /app/www/active
+
+    - start an nginx container, and fpm container and a db container
+
+  You should then have
+
+    - http access at host:8080, or directly on the container
+    - the http should point to the source code in /app/source
+
+# Day to day use
+
+## starting and stopping
+
+    $/> coach stop
+    $/> coach start
+
+## starting a specific container
+
+  - start a specific node
+
+    $/> coach @www start
+
+  - start all service nodes
+
+    $/> coach %service start
+
+## rebuild any containers
+
+  1. stop any running containers
+
+    $/> coach stop
+
+  2. remove and created containers
+
+    $/> coach remove
+
+  3. recreate and containers
+
+    $/> coach create 
+
+  4. start the new containers 
+
+    $/> coach start
+
+# Alterations that you should make
+
+## Custom DB
+
+The nodes.yml file has a better DB image commented out which you could use to get
+a DB container that has an already populated DB with specific access credentials.
+
+## Switch to PHP7 or HHVM
+
+If you want to test out the latest PHP7 or HHVM builds, try changing nodes.yml, the 
+fpm node Image values.  There are instructions above the node.
+
+Note that if you want to swap out fpm containers, you will need to stop and remove
+both the fpm and nginx nodes, alter the nodes yml, and then start www and fpm again
+(you do not need to stop the db container.)
+
+Instructions:
+
+1. Make changes to your nodes.yml (change the fpm image)
+
+2. stop www and fpm
+
+  $/> coach @fpm @www stop
+
+3. remove www and fpm containers
+
+  $/> coach @fpm @www remove
+
+4. make sure that you have all needed images
+ 
+  $/> coach pull
+  $/> coach build
+
+5. re-create www and fpm containers
+
+  $/> coach @fpm @www recreate
+
+6. restart www and fpm containers
+
+  $/> coach @fpm @www start

--- a/templates/demo/lamp/app/README.md
+++ b/templates/demo/lamp/app/README.md
@@ -1,0 +1,9 @@
+# Bare Project
+## /.coach/
+
+  Project coach configuration
+
+## /app
+
+  Project source-code and assets path
+

--- a/templates/demo/lamp/app/source/index.php
+++ b/templates/demo/lamp/app/source/index.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Put your PHP source code here
+ *
+ * Not that in this demo project, only this folder gets mapped into
+ * the source container, so relative includes that point above will
+ * fail.  You can change the source node bind as needed.
+ */
+
+phpinfo();

--- a/templates/demo/lamp_monolithic/.coach/coachinit.yml
+++ b/templates/demo/lamp_monolithic/.coach/coachinit.yml
@@ -1,0 +1,152 @@
+- Type: File
+  Path: README.md
+  Contents: |
+    # COACH DEMO: Monolithic LAMP
+
+    This coach demo provides a monolithic LAMP stack:
+
+    - server service using jamesnesbitt/wunder-lampstackplus
+
+    To incorporate source, the source code from /app/source
+    is mapped into a "source" container, which is used in
+    the nginx and fpm containers.
+
+    # Getting Started:
+
+      You already did this:
+
+        #/> coach init demo lamp_monolithic
+
+      Now just do this:
+
+        $/> coach up
+
+      This should:
+
+        - download an image
+
+        - start nginx, fpm containers and db in a single container
+          using supervisord
+
+    # Day to day use
+
+    ## starting and stopping
+
+        $/> coach stop
+        $/> coach start
+
+    ## rebuild the container
+
+      1. stop the running container
+
+        $/> coach stop
+
+      2. remove container
+
+        $/> coach remove
+
+      3. recreate container
+
+        $/> coach create
+
+      4. start the new container
+
+        $/> coach start
+
+- Type: File
+  Path: .coach/conf.yml
+  Contents: |
+    ###
+    # Coach project conf
+    #
+    # Configurations for the coach project
+    #
+    # Project: project name, used to create container names
+    # Author: used for docker commits & pushes.
+    #   @note this needs to be valid for container names/images
+    #     so it can contain alpha-numeric & "_"
+    #
+    # Tokens: a string map for string substitutions elsewhere
+    #    by using the format %{key} in files loaded after this
+    #    one
+    #
+    ###
+
+    # Project name
+    Project: lampmono
+
+    Author: me
+
+    # Custom Tokens
+    Tokens:
+      # Set a container domain, which containers can pull in as ENV or box domains
+      CONTAINER_DOMAIN: demo.coach
+
+
+- Type: File
+  Path: .coach/nodes.yml
+  Contents: |
+    ###
+    # Project nodes
+    #
+    # A string map of node configurations, each entry is a node, which 
+    # corresponds to a set of containers based on a single image.  the
+    # nodes have different types, an different purposes:
+    #
+    ###
+
+    ###
+    # A Single monolithic LAMP image
+    #
+    # This single image contains a complete running LAMP stack:
+    #   - nginx
+    #   - phpfpm56 from REMI
+    #   - mariadb from the mariadb centos repo
+    #
+    # The image is managed using supervisord
+    #
+    # @NOTE optionally use DNSDOCK to get automatic DNS out of it, or 
+    #   enable the PortBindings to get local ports as needed
+    #
+    ###
+    lampstack:
+      Type: service
+
+      Config:
+        Image: jamesnesbitt/wunder-lampstackplus # RUn from a monolithic image
+        Hostname: "%PROJECT" # Token derived from the project name in conf.yml
+        Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+        Env:
+          - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+        ExposedPorts:
+          80/tcp: {}
+
+      Host:
+        Binds:
+          - "app/source:/app/www" # map the local source folder, into where the nginx/fpm expect the web root
+    #     PortBindings:
+    #       80/tcp:
+    #         - HostPort: 8080 # Port 8080 applies to all Host IPs
+
+- Type: File
+  Path: app/README.md
+  Contents: |
+    # DEMO lamp
+
+    ## /app/source
+
+      Project source-code and assets path
+
+- Type: File
+  Path: app/source/index.php
+  Contents: |
+    <?php
+    /**
+     * Put your PHP source code here
+     *
+     * Not that in this demo project, only this folder gets mapped into
+     * the source container, so relative includes that point above will
+     * fail.  You can change the source node bind as needed.
+     */
+
+    phpinfo();

--- a/templates/demo/lamp_monolithic/.coach/conf.yml
+++ b/templates/demo/lamp_monolithic/.coach/conf.yml
@@ -1,0 +1,25 @@
+###
+# Coach project conf
+#
+# Configurations for the coach project
+#
+# Project: project name, used to create container names
+# Author: used for docker commits & pushes.
+#   @note this needs to be valid for container names/images
+#     so it can contain alpha-numeric & "_"
+#
+# Tokens: a string map for string substitutions elsewhere
+#    by using the format %{key} in files loaded after this
+#    one
+#
+###
+
+# Project name
+Project: lampmono
+
+Author: me
+
+# Custom Tokens
+Tokens:
+  # Set a container domain, which containers can pull in as ENV or box domains
+  CONTAINER_DOMAIN: demo.coach

--- a/templates/demo/lamp_monolithic/.coach/nodes.yml
+++ b/templates/demo/lamp_monolithic/.coach/nodes.yml
@@ -1,0 +1,41 @@
+###
+# Project nodes
+#
+# A string map of node configurations, each entry is a node, which 
+# corresponds to a set of containers based on a single image.  the
+# nodes have different types, an different purposes:
+#
+###
+
+###
+# A Single monolithic LAMP image
+#
+# This single image contains a complete running LAMP stack:
+#   - nginx
+#   - phpfpm56 from REMI
+#   - mariadb from the mariadb centos repo
+#
+# The image is managed using supervisord
+#
+# @NOTE optionally use DNSDOCK to get automatic DNS out of it, or 
+#   enable the PortBindings to get local ports as needed
+#
+###
+lampstack:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-lampstackplus # RUn from a monolithic image
+    Hostname: "%PROJECT" # Token derived from the project name in conf.yml
+    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+    Env:
+      - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+    ExposedPorts:
+      80/tcp: {}
+
+  Host:
+    Binds:
+      - "app/source:/app/www" # map the local source folder, into where the nginx/fpm expect the web root
+#     PortBindings:
+#       80/tcp:
+#         - HostPort: 8080 # Port 8080 applies to all Host IPs

--- a/templates/demo/lamp_monolithic/README.md
+++ b/templates/demo/lamp_monolithic/README.md
@@ -1,0 +1,51 @@
+# COACH DEMO: Monolithic LAMP
+
+This coach demo provides a monolithic LAMP stack:
+
+- server service using jamesnesbitt/wunder-lampstackplus
+
+To incorporate source, the source code from /app/source
+is mapped into a "source" container, which is used in
+the nginx and fpm containers.
+
+# Getting Started:
+
+  You already did this:
+
+    #/> coach init demo lamp_monolithic
+
+  Now just do this:
+
+    $/> coach up
+
+  This should:
+
+    - download an image
+
+    - start nginx, fpm containers and db in a single container
+      using supervisord
+
+# Day to day use
+
+## starting and stopping
+
+    $/> coach stop
+    $/> coach start
+
+## rebuild the container
+
+  1. stop the running container
+
+    $/> coach stop
+
+  2. remove container
+
+    $/> coach remove
+
+  3. recreate container
+
+    $/> coach create
+
+  4. start the new container
+
+    $/> coach start

--- a/templates/demo/lamp_monolithic/app/README.md
+++ b/templates/demo/lamp_monolithic/app/README.md
@@ -1,0 +1,5 @@
+# DEMO Lamp
+
+## /app/source
+
+  Project source-code

--- a/templates/demo/lamp_monolithic/app/source/index.php
+++ b/templates/demo/lamp_monolithic/app/source/index.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Put your PHP source code here
+ *
+ * Not that in this demo project, only this folder gets mapped into
+ * the source container, so relative includes that point above will
+ * fail.  You can change the source node bind as needed.
+ */
+
+phpinfo();

--- a/templates/demo/lamp_multiplephps/.coach/coachinit.yml
+++ b/templates/demo/lamp_multiplephps/.coach/coachinit.yml
@@ -113,17 +113,7 @@
     #    by using the format %{key} in files loaded after this
     #    one
     #
-    # Paths: a string map of paths that you can use for 
-    #    things like docker builds and mounts.  Paths can be 
-    #    absolute or relative to the project root.
-    #    Note that you can override the following paths:
-    #      - usertemplates : path to users init templates
-    #      - usersecrets : path to user secrets
-    #      - projectsecrets : path to project secrets
-    #      - build : path to builds
-    #    Paths are also made available as tokens using the
-    #    format PATH_{UPPERCASEKEY}
-    #
+    ###
 
     # Project name
     Project: lampphptests
@@ -145,83 +135,6 @@
     # A string map of node configurations, each entry is a node, which 
     # corresponds to a set of containers based on a single image.  the
     # nodes have different types, an different purposes:
-    #
-    # Nodes: 
-    #   Each element in the yml file is a keyed configuration to configure
-    #   a single coach node, which is any number of docker containers
-    #   that use a single build/image.  The nodes can be just used to 
-    #   build images, or can be used to store data, run services or run
-    #   commands.  A node can use multiple containers to provide scaling
-    #   services, or alternate services.
-    #
-    # Types:
-    #   - build: only used for building images, let's you build a base 
-    #        image for other nodes
-    #   - volume: non-running containers meant to hold files that are 
-    #        shared with other nodes
-    #   - service: a node with containers that get started and stopped
-    #   - command: a node that uses disposable containers to run commands
-    #        inside an environment
-    #
-    # Instances:
-    #   Nodes can have multiple containers called instances. The instances
-    #   setting tells coach how to treat the node instances:
-    #   - scale: allow numeric instances, and allow the scale operation 
-    #        to spin up new instanes.
-    #   - fixed: if you provide a string list of instances, then they 
-    #         can be started and stopped by name.
-    #   - temporary: instances started are removed when stopped.  For example
-    #         command containers are considered temporary.
-    #
-    #   Multiple instances are complex, especially when it comes to linking
-    #   Nodes together.  If one node is linked to another, either by Link,
-    #   or VolumesFrom, then coach tries to link matching instance names
-    #   possible (or you can user node:all to link to all)
-    #
-    # Tokens:
-    #
-    #  Tokens can be used for string substitution in this file.  Tokens can come
-    #  from the conf.yml, or from the secrets.yml (or from the users secrets.)
-    #  Tokens are substituted using a "%" prefix, before the YML is parsed, so
-    #  you may need to wrap tokenized settings in "quotes" when using them.
-    #
-    #  The following tokens are available:
-    #
-    #    - anything from the tokens section of the conf.yml
-    #    - anything from the project or user secrets.yml
-    #    
-    #    - the project name is accessible using %PROJECT
-    #    - any path value is accessible using %PATH_UPPERCASEPATHKEY
-    #    - multi-instance nodes can access the intance name as %INSTANCE
-    #
-    # Coach configuration:
-    #
-    #   - Type: You can define the node type (or it will default to service)
-    #   - Build: You can assign a Build path, which will be used to build a local
-    #        image for the node.  If you also define an image then that
-    #        is used for the image name.  If the path is relative, then it
-    #        is considered relative inside the .coach/ folder.
-    #   - Instances: a string list of instance names, or the keyword temporary
-    #        or the keyword scaled, followed by the integer values for initial
-    #        and maximum number of running containers
-    #        e.g.:
-    #           Instances: first second third
-    #           Instances: temporary
-    #           Instances: scaled 3 9
-    #
-    # Docker remote API Configurations:
-    #
-    #   The two principle parts of the configuration for a node are the 
-    #   Config and Host settings.
-    #   These wrap the client config and can use any of it's keys, which 
-    #   gives access to pretty much all of the docker remote API settings.
-    #
-    #   - Config : the dockerclient config element used define the internals
-    #        of a container.  
-    #        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L200
-    #   - Host : the dockerclient config element used to define the relationship
-    #        between the container and it's host.
-    #        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L472
     #
     ###
 
@@ -384,7 +297,7 @@
 
 
 - Type: File
-  Path: .coach/docker/db/Dockerfile
+  Path: .coach/docker/nginx/Dockerfile
   Contents: |
     FROM        jamesnesbitt/wunder-nginx
     MAINTAINER  james.nesbitt@wunderkraut.com
@@ -400,7 +313,7 @@
     ### /NGINX -------------------------------------------------------------------
 
 - Type: File
-  Path: .coach/docker/db/etc/nginx/conf.d/default.conf
+  Path: .coach/docker/nginx/etc/nginx/conf.d/default.conf
   Contents: |
     # PHP56 Server
     server {

--- a/templates/demo/lamp_multiplephps/.coach/coachinit.yml
+++ b/templates/demo/lamp_multiplephps/.coach/coachinit.yml
@@ -1,13 +1,31 @@
 - Type: File
   Path: README.md
   Contents: |
-    # COACH DEMO: Standard Lamp
+    # COACH DEMO: Lamp with multiple PHP backends
 
-    This coach demo provides a standard LAMP stack:
+    This coach demo provides an enhanced LAMP stack:
 
-    - Nginx service using jamesnesbitt/wunder-nginx
-    - PHP-FPM service using jamesnesbitt/wunder-php56fpm
     - DB service using jamesnesbitt/wunder-mariadb
+
+    - 3 fpm services, that connect a standard to a different
+      php version.  All php versions point to the same DB
+      container, and use a separate nginx host.
+        - php56fpm : from centos REMI
+        - php7fpm : from REMI-7
+        - hhvm : from EPEL I think
+
+    - 1 master nginx server that has three server{} settings
+      to point to each of the PHP FPMs using wildcarded URLS
+        - php56.* -> the php56 fpm server
+        - php7.* -> the php7 fpm server
+        - hhvm.* -> the hhvm server
+
+    @NOTE you may have to do some DNS/hosts magic to get these
+    DNS entries to resolve
+
+    This should produce 3 parrallel nginx services that
+    all point to the same source, which can be used for
+    parrallel testing.
 
     To incorporate source, the source code from /app/source
     is mapped into a "source" container, which is used in
@@ -28,7 +46,7 @@
 
       You already did this:
 
-        #/> coach init demo lampstack
+        #/> coach init demo lamp_multiplephp
 
       Now just do this:
 
@@ -40,12 +58,10 @@
         - build any local images that were defined
         - create a source container which will map ./app/source to /app/www/active
 
-        - start an nginx container, and fpm container and a db container
+        - start nginx containers, and fpm containers and a db container
 
-      You should then have
-
-        - http access at host:8080, or directly on the container
-        - the http should point to the source code in /app/source
+      You can access the different http servers directly, or set
+      different port numbers for each
 
     # Day to day use
 
@@ -54,15 +70,13 @@
         $/> coach stop
         $/> coach start
 
-    ## starting a specific container
+    ## coach targets
 
-      - start a specific node
+      You can target coach at only certain nodes using targets
 
-        $/> coach @www start
+        $/> coach @www stop
 
-      - start all service nodes
-
-        $/> coach %service start
+        $/> coach @php56 @php7 @hhvm start
 
     ## rebuild any containers
 
@@ -81,47 +95,6 @@
       4. start the new containers
 
         $/> coach start
-
-    # Alterations that you should make
-
-    ## Custom DB
-
-    The nodes.yml file has a better DB image commented out which you could use to get
-    a DB container that has an already populated DB with specific access credentials.
-
-    ## Switch to PHP7 or HHVM
-
-    If you want to test out the latest PHP7 or HHVM builds, try changing nodes.yml, the
-    fpm node Image values.  There are instructions above the node.
-
-    Note that if you want to swap out fpm containers, you will need to stop and remove
-    both the fpm and nginx nodes, alter the nodes yml, and then start www and fpm again
-    (you do not need to stop the db container.)
-
-    Instructions:
-
-    1. Make changes to your nodes.yml (change the fpm image)
-
-    2. stop www and fpm
-
-      $/> coach @fpm @www stop
-
-    3. remove www and fpm containers
-
-      $/> coach @fpm @www remove
-
-    4. make sure that you have all needed images
-
-      $/> coach pull
-      $/> coach build
-
-    5. re-create www and fpm containers
-
-      $/> coach @fpm @www recreate
-
-    6. restart www and fpm containers
-
-      $/> coach @fpm @www start
 
 
 - Type: File
@@ -153,7 +126,7 @@
     #
 
     # Project name
-    Project: lamp
+    Project: lampphptests
 
     Author: me
 
@@ -161,6 +134,7 @@
     Tokens:
       # Set a container domain, which containers can pull in as ENV or box domains
       CONTAINER_DOMAIN: demo.coach
+
 
 - Type: File
   Path: .coach/nodes.yml
@@ -281,55 +255,67 @@
         Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
 
     ###
-    # Alternative Custom Database service
+    # FPM services
     #
-    # This container uses a local build to extend a base db, adding in a database "app" and changing
-    # the root user password
-    # 
-    # @see ./coach/docker/db/Dockerfile
+    # # services are created in parrallel
+    #    - php56 : from REMI
+    #    - php7 : from REMI-7
+    #    - hhvm : from .. EPEL I think
     #
-    # This node needs building !  $/> coach build
-    #
-
-    # db:
-    #   Type: service
-    #   Build: /docker/db          # DB has a docker build so that we can create databases and set custom passwords.
-    #
-    #   Config:
-    #     RestartPolicy: on-failure
-    #     OpenStdin: true
-
-    ###
-    # FPM service
-    #
-    # This node implements a standard PHP-FPM service, which you can connect to over
-    # TCP/IP.  The node has access to the source via the source container, and the db
+    # Each node implements a standard PHP-FPM service, which you can connect to over
+    # TCP/IP.  Each node has access to the source via the source container, and the db
     # using a docker link (accessible over TCP/IP at db.app)
     #
-    # There are alternative PHP images that you could try, to test out HHVM or PHP7
-    # But note that if you switch, you have to recreate the container.
-    #
-    # Note that the WWW node needs this container
-    #
-    fpm:
+    hhvm:
       Type: service
 
       Config:
-        #Image: jamesnesbitt/wunder-hhvm      # The HHVM works
-        Image: jamesnesbitt/wunder-php56fpm     # The FPM works, and should have blackfire working
-        #Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+        Image: jamesnesbitt/wunder-hhvm      # The HHVM works
 
       Host:
         Links:
           - db:db.app # make the db container available as db.app
         VolumesFrom:
           - source  # map in all volumes from the source container
+
+    php56:
+      Type: service
+
+      Config:
+        Image: jamesnesbitt/wunder-php56fpm     # The FPM works, and should have blackfire working
+
+      Host:
+        Links:
+          - db:db.app # make the db container available as db.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
+
+    php7:
+      Type: service
+
+      Config:
+        Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+      Host:
+        Links:
+          - db:db.app # make the db container available as db.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
+
     ###
     # WWW service
     #
     # An nginx service, that handles http requests, and passes PHP parsing off to 
     # the fpm node.  This node has some custom configurations to try to get it
     # to respond to different URLs appropriately
+    #
+    # This nginx server handles URLS as follows:
+    #   php56.* => goes to the php56 fpm
+    #   php7.* => goes to the php7 fpm
+    #   hhvm.* => goes to the hhvm fpm
+    #
+    # @note you may need to do some DNS magic to get your machine to point to
+    #  the www container for all three URLs, but that is your business.
     #
     # @note that this container binds to the host port for 8080, but can still be 
     #   resolved by pointing to port 80 on the container IP
@@ -338,9 +324,9 @@
     #
     www:
       Type: service
+      Build: docker/nginx # We need a custom nginx build to handler multiple URLS and multiple FPMs
 
       Config:
-        Image: jamesnesbitt/wunder-nginx  # recent nginx build using nginx provided centos repo
         Hostname: "%PROJECT" # Token derived from the project name in conf.yml
         Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
         Env:
@@ -350,17 +336,25 @@
 
       Host:
         Links:
-          - fpm:fpm.app # make the fpm service available as fpm.app
+          - php56:php56.fpm.app # make the fpm service available as fpm.app
+          - php7:php7.fpm.app # make the fpm service available as fpm.app
+          - hhvm:hhvm.fpm.app # make the fpm service available as fpm.app
         VolumesFrom:
           - source  # map in all volumes from the source container
-        PortBindings:
-          80/tcp:
-            - HostPort: 8080 # Port 80 applies to all Host IPs
+    #     PortBindings:
+    #       80/tcp:
+    #         - HostPort: 8080 # Port 80 applies to all Host IPs
+
 
 - Type: File
   Path: app/README.md
   Contents: |
-    # DEMO lamp
+    # DEMO lamp : multiple PHP options
+
+      Test your project with various PHP backends
+        - PHP56
+        - PHP7
+        - HHVM
 
     ## /app/source
 
@@ -381,37 +375,236 @@
     phpinfo();
 
 - Type: File
-  Path: .coach/docker/db/README.md
+  Path: .coach/docker/nginx/README.md
   Contents: |
-    # DB Docker Build
+    # custom nginx build
 
-    This is a Docker build that can optionally be used for building a custom Database
-    image for the local project.
+    This demo uses a custom nginx build, which overrides the default.conf
+    nginx conf, to allow for 3 server{} listeners, 1 for each fpm service.
 
-    To use this build, add "docker/db" (the path inside the .coach folder) to an node,
-    and then you can use "$/> docker build" to build all node images
 
 - Type: File
   Path: .coach/docker/db/Dockerfile
   Contents: |
-    FROM        jamesnesbitt/wunder-mariadb
+    FROM        jamesnesbitt/wunder-nginx
     MAINTAINER  james.nesbitt@wunderkraut.com
 
-    ### ProjectDB --------------------------------------------------------------------
+    ### NGINX --------------------------------------------------------------------
 
-
-    # Create our project DB
+    # Use new nginx vhost confs
     #
-    # - set the root user password to something safe (considered a good idea)
-    # - create an "app" database
-    # - give access to the new database to an "app" user using the password "app"
-    # - app user can only access from 172.* IPs !!!! (inside the docker subnet)
-    # - flush access
+    # This new conf send connections to one of three fpm servers
     #
-    RUN (/usr/bin/mysqld_safe &) && sleep 5 && \
-        mysql -uroot -e "UPDATE mysql.user SET Password=PASSWORD('H4x0r') WHERE User='root'" && \
-        mysql -uroot -e "CREATE DATABASE app" && \
-        mysql -uroot -e "GRANT ALL ON app.* to app@'172.%' IDENTIFIED BY 'app'" && \
-        mysql -uroot -e "FLUSH PRIVILEGES"
+    ADD etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 
-    ### /ProjectDB -------------------------------------------------------------------
+    ### /NGINX -------------------------------------------------------------------
+
+- Type: File
+  Path: .coach/docker/db/etc/nginx/conf.d/default.conf
+  Contents: |
+    # PHP56 Server
+    server {
+      listen       80;
+      server_name  php56.*;
+      root /app/www/active;
+
+      error_log /app/log/nginx/php56.error.log;
+      access_log /app/log/nginx/php56.access.log;
+
+      charset utf8;
+
+      gzip_static on;
+
+      location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+      }
+
+      location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+      }
+
+      location ~ \..*/.*\.php$ {
+        return 403;
+      }
+
+      # No no for private
+      location ~ ^/sites/.*/private/ {
+        return 403;
+      }
+
+      # Block access to "hidden" files and directories whose names begin with a
+      # period. This includes directories used by version control systems such
+      # as Subversion or Git to store control files.
+      location ~ (^|/)\. {
+        return 403;
+      }
+
+      location / {
+        # This is cool because no php is touched for static content
+        try_files $uri @rewrite;
+      }
+
+      location @rewrite {
+        rewrite ^ /index.php;
+      }
+
+      location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_intercept_errors on;
+        fastcgi_pass php56.fpm.app:9000;
+      }
+
+      # Fighting with Styles? This little gem is amazing.
+      location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+      }
+
+      location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires max;
+        log_not_found off;
+      }
+    }
+
+    # PHP7 Server
+    server {
+      listen       80;
+      server_name  php7.*;
+      root /app/www/active;
+
+      error_log /app/log/nginx/php7.error.log;
+      access_log /app/log/nginx/php7.access.log;
+
+      charset utf8;
+
+      gzip_static on;
+
+      location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+      }
+
+      location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+      }
+
+      location ~ \..*/.*\.php$ {
+        return 403;
+      }
+
+      # No no for private
+      location ~ ^/sites/.*/private/ {
+        return 403;
+      }
+
+      # Block access to "hidden" files and directories whose names begin with a
+      # period. This includes directories used by version control systems such
+      # as Subversion or Git to store control files.
+      location ~ (^|/)\. {
+        return 403;
+      }
+
+      location / {
+        # This is cool because no php is touched for static content
+        try_files $uri @rewrite;
+      }
+
+      location @rewrite {
+        rewrite ^ /index.php;
+      }
+
+      location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_intercept_errors on;
+        fastcgi_pass php7.fpm.app:9000;
+      }
+
+      # Fighting with Styles? This little gem is amazing.
+      location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+      }
+
+      location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires max;
+        log_not_found off;
+      }
+    }
+
+    # HHVM Server
+    server {
+      listen       80;
+      server_name  hhvm.*;
+      root /app/www/active;
+
+      error_log /app/log/nginx/hhvm.error.log;
+      access_log /app/log/nginx/hhvm.access.log;
+
+      charset utf8;
+
+      gzip_static on;
+
+      location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+      }
+
+      location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+      }
+
+      location ~ \..*/.*\.php$ {
+        return 403;
+      }
+
+      # No no for private
+      location ~ ^/sites/.*/private/ {
+        return 403;
+      }
+
+      # Block access to "hidden" files and directories whose names begin with a
+      # period. This includes directories used by version control systems such
+      # as Subversion or Git to store control files.
+      location ~ (^|/)\. {
+        return 403;
+      }
+
+      location / {
+        # This is cool because no php is touched for static content
+        try_files $uri @rewrite;
+      }
+
+      location @rewrite {
+        rewrite ^ /index.php;
+      }
+
+      location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_intercept_errors on;
+        fastcgi_pass hhvm.fpm.app:9000;
+      }
+
+      # Fighting with Styles? This little gem is amazing.
+      location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+      }
+
+      location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires max;
+        log_not_found off;
+      }
+    }

--- a/templates/demo/lamp_multiplephps/.coach/conf.yml
+++ b/templates/demo/lamp_multiplephps/.coach/conf.yml
@@ -1,0 +1,34 @@
+# Coach project conf
+#
+# Configurations for the coach project
+#
+# Project: project name, used to create container names
+# Author: used for docker commits & pushes.
+#   @note this needs to be valid for container names/images
+#     so it can contain alpha-numeric & "_"
+#
+# Tokens: a string map for string substitutions elsewhere
+#    by using the format %{key} in files loaded after this
+#    one
+#
+# Paths: a string map of paths that you can use for 
+#    things like docker builds and mounts.  Paths can be 
+#    absolute or relative to the project root.
+#    Note that you can override the following paths:
+#      - usertemplates : path to users init templates
+#      - usersecrets : path to user secrets
+#      - projectsecrets : path to project secrets
+#      - build : path to builds
+#    Paths are also made available as tokens using the
+#    format PATH_{UPPERCASEKEY}
+#
+
+# Project name
+Project: lampphptests
+
+Author: me
+
+# Custom Tokens
+Tokens:
+  # Set a container domain, which containers can pull in as ENV or box domains
+  CONTAINER_DOMAIN: demo.coach

--- a/templates/demo/lamp_multiplephps/.coach/conf.yml
+++ b/templates/demo/lamp_multiplephps/.coach/conf.yml
@@ -11,17 +11,7 @@
 #    by using the format %{key} in files loaded after this
 #    one
 #
-# Paths: a string map of paths that you can use for 
-#    things like docker builds and mounts.  Paths can be 
-#    absolute or relative to the project root.
-#    Note that you can override the following paths:
-#      - usertemplates : path to users init templates
-#      - usersecrets : path to user secrets
-#      - projectsecrets : path to project secrets
-#      - build : path to builds
-#    Paths are also made available as tokens using the
-#    format PATH_{UPPERCASEKEY}
-#
+###
 
 # Project name
 Project: lampphptests

--- a/templates/demo/lamp_multiplephps/.coach/docker/nginx/Dockerfile
+++ b/templates/demo/lamp_multiplephps/.coach/docker/nginx/Dockerfile
@@ -1,0 +1,12 @@
+FROM        jamesnesbitt/wunder-nginx
+MAINTAINER  james.nesbitt@wunderkraut.com
+
+### NGINX --------------------------------------------------------------------
+
+# Use new nginx vhost confs
+#
+# This new conf send connections to one of three fpm servers
+#
+ADD etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+
+### /NGINX -------------------------------------------------------------------

--- a/templates/demo/lamp_multiplephps/.coach/docker/nginx/README.md
+++ b/templates/demo/lamp_multiplephps/.coach/docker/nginx/README.md
@@ -1,0 +1,4 @@
+# custom nginx build
+
+This demo uses a custom nginx build, which overrides the default.conf
+nginx conf, to allow for 3 server{} listeners, 1 for each fpm service.

--- a/templates/demo/lamp_multiplephps/.coach/docker/nginx/etc/nginx/conf.d/default.conf
+++ b/templates/demo/lamp_multiplephps/.coach/docker/nginx/etc/nginx/conf.d/default.conf
@@ -1,0 +1,207 @@
+
+# PHP56 Server
+server {
+  listen       80;
+  server_name  php56.*;
+  root /app/www/active;
+
+  error_log /app/log/nginx/php56.error.log;
+  access_log /app/log/nginx/php56.access.log;
+
+  charset utf8;
+
+  gzip_static on;
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+  }
+
+  location ~ \..*/.*\.php$ {
+    return 403;
+  }
+
+  # No no for private
+  location ~ ^/sites/.*/private/ {
+    return 403;
+  }
+
+  # Block access to "hidden" files and directories whose names begin with a
+  # period. This includes directories used by version control systems such
+  # as Subversion or Git to store control files.
+  location ~ (^|/)\. {
+    return 403;
+  }
+
+  location / {
+    # This is cool because no php is touched for static content
+    try_files $uri @rewrite;
+  }
+
+  location @rewrite {
+    rewrite ^ /index.php;
+  }
+
+  location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
+    fastcgi_intercept_errors on;
+    fastcgi_pass php56.fpm.app:9000;
+  }
+
+  # Fighting with Styles? This little gem is amazing.
+  location ~ ^/sites/.*/files/styles/ {
+    try_files $uri @rewrite;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires max;
+    log_not_found off;
+  }
+}
+
+# PHP7 Server
+server {
+  listen       80;
+  server_name  php7.*;
+  root /app/www/active;
+
+  error_log /app/log/nginx/php7.error.log;
+  access_log /app/log/nginx/php7.access.log;
+
+  charset utf8;
+
+  gzip_static on;
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+  }
+
+  location ~ \..*/.*\.php$ {
+    return 403;
+  }
+
+  # No no for private
+  location ~ ^/sites/.*/private/ {
+    return 403;
+  }
+
+  # Block access to "hidden" files and directories whose names begin with a
+  # period. This includes directories used by version control systems such
+  # as Subversion or Git to store control files.
+  location ~ (^|/)\. {
+    return 403;
+  }
+
+  location / {
+    # This is cool because no php is touched for static content
+    try_files $uri @rewrite;
+  }
+
+  location @rewrite {
+    rewrite ^ /index.php;
+  }
+
+  location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
+    fastcgi_intercept_errors on;
+    fastcgi_pass php7.fpm.app:9000;
+  }
+
+  # Fighting with Styles? This little gem is amazing.
+  location ~ ^/sites/.*/files/styles/ {
+    try_files $uri @rewrite;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires max;
+    log_not_found off;
+  }
+}
+
+# HHVM Server
+server {
+  listen       80;
+  server_name  hhvm.*;
+  root /app/www/active;
+
+  error_log /app/log/nginx/hhvm.error.log;
+  access_log /app/log/nginx/hhvm.access.log;
+
+  charset utf8;
+
+  gzip_static on;
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+  }
+
+  location ~ \..*/.*\.php$ {
+    return 403;
+  }
+
+  # No no for private
+  location ~ ^/sites/.*/private/ {
+    return 403;
+  }
+
+  # Block access to "hidden" files and directories whose names begin with a
+  # period. This includes directories used by version control systems such
+  # as Subversion or Git to store control files.
+  location ~ (^|/)\. {
+    return 403;
+  }
+
+  location / {
+    # This is cool because no php is touched for static content
+    try_files $uri @rewrite;
+  }
+
+  location @rewrite {
+    rewrite ^ /index.php;
+  }
+
+  location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
+    fastcgi_intercept_errors on;
+    fastcgi_pass hhvm.fpm.app:9000;
+  }
+
+  # Fighting with Styles? This little gem is amazing.
+  location ~ ^/sites/.*/files/styles/ {
+    try_files $uri @rewrite;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires max;
+    log_not_found off;
+  }
+}

--- a/templates/demo/lamp_multiplephps/.coach/nodes.yml
+++ b/templates/demo/lamp_multiplephps/.coach/nodes.yml
@@ -5,83 +5,6 @@
 # corresponds to a set of containers based on a single image.  the
 # nodes have different types, an different purposes:
 #
-# Nodes: 
-#   Each element in the yml file is a keyed configuration to configure
-#   a single coach node, which is any number of docker containers
-#   that use a single build/image.  The nodes can be just used to 
-#   build images, or can be used to store data, run services or run
-#   commands.  A node can use multiple containers to provide scaling
-#   services, or alternate services.
-#
-# Types:
-#   - build: only used for building images, let's you build a base 
-#        image for other nodes
-#   - volume: non-running containers meant to hold files that are 
-#        shared with other nodes
-#   - service: a node with containers that get started and stopped
-#   - command: a node that uses disposable containers to run commands
-#        inside an environment
-#
-# Instances:
-#   Nodes can have multiple containers called instances. The instances
-#   setting tells coach how to treat the node instances:
-#   - scale: allow numeric instances, and allow the scale operation 
-#        to spin up new instanes.
-#   - fixed: if you provide a string list of instances, then they 
-#         can be started and stopped by name.
-#   - temporary: instances started are removed when stopped.  For example
-#         command containers are considered temporary.
-#
-#   Multiple instances are complex, especially when it comes to linking
-#   Nodes together.  If one node is linked to another, either by Link,
-#   or VolumesFrom, then coach tries to link matching instance names
-#   possible (or you can user node:all to link to all)
-#
-# Tokens:
-#
-#  Tokens can be used for string substitution in this file.  Tokens can come
-#  from the conf.yml, or from the secrets.yml (or from the users secrets.)
-#  Tokens are substituted using a "%" prefix, before the YML is parsed, so
-#  you may need to wrap tokenized settings in "quotes" when using them.
-#
-#  The following tokens are available:
-#
-#    - anything from the tokens section of the conf.yml
-#    - anything from the project or user secrets.yml
-#    
-#    - the project name is accessible using %PROJECT
-#    - any path value is accessible using %PATH_UPPERCASEPATHKEY
-#    - multi-instance nodes can access the intance name as %INSTANCE
-#
-# Coach configuration:
-#
-#   - Type: You can define the node type (or it will default to service)
-#   - Build: You can assign a Build path, which will be used to build a local
-#        image for the node.  If you also define an image then that
-#        is used for the image name.  If the path is relative, then it
-#        is considered relative inside the .coach/ folder.
-#   - Instances: a string list of instance names, or the keyword temporary
-#        or the keyword scaled, followed by the integer values for initial
-#        and maximum number of running containers
-#        e.g.:
-#           Instances: first second third
-#           Instances: temporary
-#           Instances: scaled 3 9
-#
-# Docker remote API Configurations:
-#
-#   The two principle parts of the configuration for a node are the 
-#   Config and Host settings.
-#   These wrap the client config and can use any of it's keys, which 
-#   gives access to pretty much all of the docker remote API settings.
-#
-#   - Config : the dockerclient config element used define the internals
-#        of a container.  
-#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L200
-#   - Host : the dockerclient config element used to define the relationship
-#        between the container and it's host.
-#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L472
-#
 ###
 
 ###
@@ -202,4 +125,4 @@ www:
       - source  # map in all volumes from the source container
 #     PortBindings:
 #       80/tcp:
-#         - HostPort: 8080 # Port 80 applies to all Host IPs
+#         - HostPort: 8080 # Port 8080 applies to all Host IPs

--- a/templates/demo/lamp_multiplephps/.coach/nodes.yml
+++ b/templates/demo/lamp_multiplephps/.coach/nodes.yml
@@ -1,0 +1,205 @@
+###
+# Project nodes
+#
+# A string map of node configurations, each entry is a node, which 
+# corresponds to a set of containers based on a single image.  the
+# nodes have different types, an different purposes:
+#
+# Nodes: 
+#   Each element in the yml file is a keyed configuration to configure
+#   a single coach node, which is any number of docker containers
+#   that use a single build/image.  The nodes can be just used to 
+#   build images, or can be used to store data, run services or run
+#   commands.  A node can use multiple containers to provide scaling
+#   services, or alternate services.
+#
+# Types:
+#   - build: only used for building images, let's you build a base 
+#        image for other nodes
+#   - volume: non-running containers meant to hold files that are 
+#        shared with other nodes
+#   - service: a node with containers that get started and stopped
+#   - command: a node that uses disposable containers to run commands
+#        inside an environment
+#
+# Instances:
+#   Nodes can have multiple containers called instances. The instances
+#   setting tells coach how to treat the node instances:
+#   - scale: allow numeric instances, and allow the scale operation 
+#        to spin up new instanes.
+#   - fixed: if you provide a string list of instances, then they 
+#         can be started and stopped by name.
+#   - temporary: instances started are removed when stopped.  For example
+#         command containers are considered temporary.
+#
+#   Multiple instances are complex, especially when it comes to linking
+#   Nodes together.  If one node is linked to another, either by Link,
+#   or VolumesFrom, then coach tries to link matching instance names
+#   possible (or you can user node:all to link to all)
+#
+# Tokens:
+#
+#  Tokens can be used for string substitution in this file.  Tokens can come
+#  from the conf.yml, or from the secrets.yml (or from the users secrets.)
+#  Tokens are substituted using a "%" prefix, before the YML is parsed, so
+#  you may need to wrap tokenized settings in "quotes" when using them.
+#
+#  The following tokens are available:
+#
+#    - anything from the tokens section of the conf.yml
+#    - anything from the project or user secrets.yml
+#    
+#    - the project name is accessible using %PROJECT
+#    - any path value is accessible using %PATH_UPPERCASEPATHKEY
+#    - multi-instance nodes can access the intance name as %INSTANCE
+#
+# Coach configuration:
+#
+#   - Type: You can define the node type (or it will default to service)
+#   - Build: You can assign a Build path, which will be used to build a local
+#        image for the node.  If you also define an image then that
+#        is used for the image name.  If the path is relative, then it
+#        is considered relative inside the .coach/ folder.
+#   - Instances: a string list of instance names, or the keyword temporary
+#        or the keyword scaled, followed by the integer values for initial
+#        and maximum number of running containers
+#        e.g.:
+#           Instances: first second third
+#           Instances: temporary
+#           Instances: scaled 3 9
+#
+# Docker remote API Configurations:
+#
+#   The two principle parts of the configuration for a node are the 
+#   Config and Host settings.
+#   These wrap the client config and can use any of it's keys, which 
+#   gives access to pretty much all of the docker remote API settings.
+#
+#   - Config : the dockerclient config element used define the internals
+#        of a container.  
+#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L200
+#   - Host : the dockerclient config element used to define the relationship
+#        between the container and it's host.
+#        https://github.com/fsouza/go-dockerclient/blob/master/container.go#L472
+#
+###
+
+###
+# A volume container to hold source
+#
+# Using a conmtainer to hold source, even if it just locally binded source, is
+# a good idea, because it replicates what a production service would do.  It would
+# have source copied/exported/retrieved in, and make it available in the same way
+#
+source:
+  Type: volume
+
+  Config:
+    Image: jamesnesbitt/wunder-base # RUn from a standard base image
+  Host:
+    Binds:
+      - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+
+###
+# Database service
+#
+# This container is a base DB image with no existing DB, nor access.  Consider 
+# using a local build, to extend a base DB image, adding in a db, adding a user
+# and setting exactly what access credentials that you want
+#
+db:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+
+###
+# FPM services
+#
+# # services are created in parrallel
+#    - php56 : from REMI
+#    - php7 : from REMI-7
+#    - hhvm : from .. EPEL I think
+#
+# Each node implements a standard PHP-FPM service, which you can connect to over
+# TCP/IP.  Each node has access to the source via the source container, and the db
+# using a docker link (accessible over TCP/IP at db.app)
+#
+hhvm:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-hhvm      # The HHVM works
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+
+php56:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-php56fpm     # The FPM works, and should have blackfire working
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+
+php7:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+
+###
+# WWW service
+#
+# An nginx service, that handles http requests, and passes PHP parsing off to 
+# the fpm node.  This node has some custom configurations to try to get it
+# to respond to different URLs appropriately
+#
+# This nginx server handles URLS as follows:
+#   php56.* => goes to the php56 fpm
+#   php7.* => goes to the php7 fpm
+#   hhvm.* => goes to the hhvm fpm
+#
+# @note you may need to do some DNS magic to get your machine to point to
+#  the www container for all three URLs, but that is your business.
+#
+# @note that this container binds to the host port for 8080, but can still be 
+#   resolved by pointing to port 80 on the container IP
+# @note that if you are using DNSDOCK, the DNSDOCK_ALIAS will help you browser to the service
+# @note https is an option if you set up the image properly.
+#
+www:
+  Type: service
+  Build: docker/nginx # We need a custom nginx build to handler multiple URLS and multiple FPMs
+
+  Config:
+    Hostname: "%PROJECT" # Token derived from the project name in conf.yml
+    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+    Env:
+      - "DNSDOCK_ALIAS=%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+    ExposedPorts:
+      80/tcp: {}
+
+  Host:
+    Links:
+      - php56:php56.fpm.app # make the fpm service available as fpm.app
+      - php7:php7.fpm.app # make the fpm service available as fpm.app
+      - hhvm:hhvm.fpm.app # make the fpm service available as fpm.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+#     PortBindings:
+#       80/tcp:
+#         - HostPort: 8080 # Port 80 applies to all Host IPs

--- a/templates/demo/lamp_multiplephps/README.md
+++ b/templates/demo/lamp_multiplephps/README.md
@@ -1,0 +1,94 @@
+# COACH DEMO: Lamp with multiple PHP backends
+
+This coach demo provides an ehnanced LAMP stack:
+
+- DB service using jamesnesbitt/wunder-mariadb
+
+- 3 fpm services, that connect a standard to a different 
+  php version.  All php versions point to the same DB 
+  container, and use a separate nginx host.
+    - php56fpm : from centos REMI
+    - php7fpm : from REMI-7
+    - hhvm : from EPEL I think
+
+- 1 master nginx server that has three server{} settings
+  to point to each of the PHP FPMs using wildcarded URLS
+    - php56.* -> the php56 fpm server
+    - php7.* -> the php7 fpm server
+    - hhvm.* -> the hhvm server
+
+@NOTE you may have to do some DNS/hosts magic to get these
+DNS entries to resolve
+
+This should produce 3 parrallel nginx services that 
+all point to the same source, which can be used for 
+parrallel testing.
+
+To incorporate source, the source code from /app/source
+is mapped into a "source" container, which is used in
+the nginx and fpm containers.
+
+The Database is un-initialized, but an optional init
+build for a db has been included, and you can switch to
+it by removing the db node, and uncommenting the custom
+db node.
+
+All of the suggested images in this project are based on
+the wunder-base concept, which is used to provide a commong
+/app project folder, and similar users/OS, to keep access
+privileges working better.
+The builds are all CentOS7, EPEL and often REMI based builds.
+
+# Getting Started:
+
+  You already did this:
+
+    #/> coach init demo lamp_multiplephp
+
+  Now just do this:
+
+    $/> coach up
+
+  This should:
+
+    - download some images
+    - build any local images that were defined
+    - create a source container which will map ./app/source to /app/www/active
+
+    - start nginx containers, and fpm containers and a db container
+
+  You can access the different http servers directly, or set
+  different port numbers for each
+
+# Day to day use
+
+## starting and stopping
+
+    $/> coach stop
+    $/> coach start
+
+## coach targets
+
+  You can target coach at only certain nodes using targets
+
+    $/> coach @www stop
+
+    $/> coach @php56 @php7 @hhvm start
+
+## rebuild any containers
+
+  1. stop any running containers
+
+    $/> coach stop
+
+  2. remove and created containers
+
+    $/> coach remove
+
+  3. recreate and containers
+
+    $/> coach create
+
+  4. start the new containers
+
+    $/> coach start

--- a/templates/demo/lamp_multiplephps/app/README.md
+++ b/templates/demo/lamp_multiplephps/app/README.md
@@ -1,0 +1,5 @@
+# DEMO Lamp - multiple phps
+
+## /app/source
+
+  Project source-code

--- a/templates/demo/lamp_multiplephps/app/source/index.php
+++ b/templates/demo/lamp_multiplephps/app/source/index.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Put your PHP source code here
+ *
+ * Not that in this demo project, only this folder gets mapped into
+ * the source container, so relative includes that point above will
+ * fail.  You can change the source node bind as needed.
+ */
+
+phpinfo();

--- a/templates/demo/lamp_scaling/.coach/coachinit.yml
+++ b/templates/demo/lamp_scaling/.coach/coachinit.yml
@@ -136,108 +136,107 @@
 - Type: File
   Path: .coach/nodes.yml
   Contents: |
-###
-# Project nodes
-#
-# A string map of node configurations, each entry is a node, which 
-# corresponds to a set of containers based on a single image.  the
-# nodes have different types, an different purposes:
-#
-# Instances
-#
-# Note that while the source and db nodes will have single containers,
-# the www and fpm nodes will run somewhere between 3 and 9 containers
-# The www and fpm containers will try to correspond their links, but
-# all fpm containers will connect to the same DB and source containers
-#
-###
+    ###
+    # Project nodes
+    #
+    # A string map of node configurations, each entry is a node, which 
+    # corresponds to a set of containers based on a single image.  the
+    # nodes have different types, an different purposes:
+    #
+    # Instances
+    #
+    # Note that while the source and db nodes will have single containers,
+    # the www and fpm nodes will run somewhere between 3 and 9 containers
+    # The www and fpm containers will try to correspond their links, but
+    # all fpm containers will connect to the same DB and source containers
+    #
+    ###
 
-###
-# A volume container to hold source
-#
-# Using a conmtainer to hold source, even if it just locally binded source, is
-# a good idea, because it replicates what a production service would do.  It would
-# have source copied/exported/retrieved in, and make it available in the same way
-#
-source:
-  Type: volume
+    ###
+    # A volume container to hold source
+    #
+    # Using a conmtainer to hold source, even if it just locally binded source, is
+    # a good idea, because it replicates what a production service would do.  It would
+    # have source copied/exported/retrieved in, and make it available in the same way
+    #
+    source:
+      Type: volume
 
-  Config:
-    Image: jamesnesbitt/wunder-base # RUn from a standard base image
-  Host:
-    Binds:
-      - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+      Config:
+        Image: jamesnesbitt/wunder-base # RUn from a standard base image
+      Host:
+        Binds:
+          - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
 
-###
-# Database service
-#
-# This container is a base DB image with no existing DB, nor access.  Consider 
-# using a local build, to extend a base DB image, adding in a db, adding a user
-# and setting exactly what access credentials that you want
-#
-db:
-  Type: service
+    ###
+    # Database service
+    #
+    # This container is a base DB image with no existing DB, nor access.  Consider 
+    # using a local build, to extend a base DB image, adding in a db, adding a user
+    # and setting exactly what access credentials that you want
+    #
+    db:
+      Type: service
 
-  Config:
-    Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+      Config:
+        Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
 
-###
-# FPM service
-#
-# This node implements a scaling number of PHP7 FPM services from the same
-# image, running concurrently.
-#
-# Each instance will connect to the same single DB container.
-#
-fpm:
-  Type: service
+    ###
+    # FPM service
+    #
+    # This node implements a scaling number of PHP7 FPM services from the same
+    # image, running concurrently.
+    #
+    # Each instance will connect to the same single DB container.
+    #
+    fpm:
+      Type: service
 
-  Instances: scaled 3 9
+      Instances: scaled 3 9
 
-  Config:
-    Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+      Config:
+        Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
 
-  Host:
-    Links:
-      - db:db.app # make the db container available as db.app
-    VolumesFrom:
-      - source  # map in all volumes from the source container
+      Host:
+        Links:
+          - db:db.app # make the db container available as db.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
 
-###
-# WWW service
-#
-# A scaling nginx node, that offers multiple instances of the same
-# image running concurrently.
-#
-# Each instance expects to have a matching FPM instance to link to
-# and will try to link to the instance with the matching instance id
-#
-# @note instance IDs are integer values
-# @note the container hostname will include the instance
-#
-www:
-  Type: service
+    ###
+    # WWW service
+    #
+    # A scaling nginx node, that offers multiple instances of the same
+    # image running concurrently.
+    #
+    # Each instance expects to have a matching FPM instance to link to
+    # and will try to link to the instance with the matching instance id
+    #
+    # @note instance IDs are integer values
+    # @note the container hostname will include the instance
+    #
+    www:
+      Type: service
 
-  Instances: scaled 3 9
+      Instances: scaled 3 9
 
-  Config:
-    Image: jamesnesbitt/wunder-nginx  # Recent nginx build using nginx provided centos repo
-    Hostname: "%PROJECT_%INSTANCE" # Tokens derived from the project and instance id
-    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
-    Env:
-      - "DNSDOCK_ALIAS=%INSTANCE.%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
-    ExposedPorts:
-      80/tcp: {}
+      Config:
+        Image: jamesnesbitt/wunder-nginx  # Recent nginx build using nginx provided centos repo
+        Hostname: "%PROJECT_%INSTANCE" # Tokens derived from the project and instance id
+        Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+        Env:
+          - "DNSDOCK_ALIAS=%INSTANCE.%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+        ExposedPorts:
+          80/tcp: {}
 
-  Host:
-    Links:
-      - fpm:fpm.app # make the fpm service available as fpm.app
-    VolumesFrom:
-      - source  # map in all volumes from the source container
-    PortBindings:
-      80/tcp:
-        - HostPort: "808%INSTANCE" # Port 808X applies to all Host IPs
-
+      Host:
+        Links:
+          - fpm:fpm.app # make the fpm service available as fpm.app
+        VolumesFrom:
+          - source  # map in all volumes from the source container
+        PortBindings:
+          80/tcp:
+            - HostPort: "808%INSTANCE" # Port 808X applies to all Host IPs
 
 - Type: File
   Path: app/README.md

--- a/templates/demo/lamp_scaling/.coach/coachinit.yml
+++ b/templates/demo/lamp_scaling/.coach/coachinit.yml
@@ -1,0 +1,263 @@
+- Type: File
+  Path: README.md
+  Contents: |
+    # COACH DEMO: Scaling LAMP
+
+    This coach demo provides a scaling LAMP stack:
+
+    - a single DB service using jamesnesbitt/wunder-mariadb
+
+    - a scaling set of nginx/fpm pairs, starting at 3
+      but scaling up to 9 instances.
+
+      @these come in pairs to allow scaling http access, but
+        DNS should work if you do some local magic.
+
+    To incorporate source, the source code from /app/source
+    is mapped into a "source" container, which is used in
+    the nginx and fpm containers.
+
+    The Database is un-initialized, but an optional init
+    build for a db has been included, and you can switch to
+    it by removing the db node, and uncommenting the custom
+    db node.
+
+    All of the suggested images in this project are based on
+    the wunder-base concept, which is used to provide a commong
+    /app project folder, and similar users/OS, to keep access
+    privileges working better.
+    The builds are all CentOS7, EPEL and often REMI based builds.
+
+    # Getting Started:
+
+      You already did this:
+
+        #/> coach init demo lamp_scaling
+
+      Now just do this:
+
+        $/> coach up
+
+      This should:
+
+        - download some images
+        - build any local images that were defined
+        - create a source container which will map ./app/source to /app/www/active
+
+        - start some nginx containers, and  some fpm containers and a single db container
+
+      You should then have
+
+        - http access to all nginx services by directly pointing to the container
+
+    # Day to day use
+
+    ## starting and stopping
+
+        $/> coach stop
+        $/> coach start
+
+    ## starting and stopping more instances
+
+      Use the scale operation to start additional instances:
+
+        $/> coach scale up
+
+      And the same operation to scale down
+
+        $/> coach scale down
+
+    ## starting a specific container
+
+      - start a specific node
+
+        $/> coach @www start
+
+      - start all service nodes
+
+        $/> coach %service start
+
+    ## rebuild any containers
+
+      1. stop any running containers
+
+        $/> coach stop
+
+      2. remove and created containers
+
+        $/> coach remove
+
+      3. recreate and containers
+
+        $/> coach create
+
+      4. start the new containers
+
+        $/> coach start
+
+- Type: File
+  Path: .coach/conf.yml
+  Contents: |
+    # Coach project conf
+    #
+    # Configurations for the coach project
+    #
+    # Project: project name, used to create container names
+    # Author: used for docker commits & pushes.
+    #   @note this needs to be valid for container names/images
+    #     so it can contain alpha-numeric & "_"
+    #
+    # Tokens: a string map for string substitutions elsewhere
+    #    by using the format %{key} in files loaded after this
+    #    one
+    #
+    # Paths: a string map of paths that you can use for 
+    #    things like docker builds and mounts.  Paths can be 
+    #    absolute or relative to the project root.
+    #    Note that you can override the following paths:
+    #      - usertemplates : path to users init templates
+    #      - usersecrets : path to user secrets
+    #      - projectsecrets : path to project secrets
+    #      - build : path to builds
+    #    Paths are also made available as tokens using the
+    #    format PATH_{UPPERCASEKEY}
+    #
+
+    # Project name
+    Project: lampscaler
+
+    Author: me
+
+    # Custom Tokens
+    Tokens:
+      # Set a container domain, which containers can pull in as ENV or box domains
+      CONTAINER_DOMAIN: demo.coach
+
+- Type: File
+  Path: .coach/nodes.yml
+  Contents: |
+###
+# Project nodes
+#
+# A string map of node configurations, each entry is a node, which 
+# corresponds to a set of containers based on a single image.  the
+# nodes have different types, an different purposes:
+#
+# Instances
+#
+# Note that while the source and db nodes will have single containers,
+# the www and fpm nodes will run somewhere between 3 and 9 containers
+# The www and fpm containers will try to correspond their links, but
+# all fpm containers will connect to the same DB and source containers
+#
+###
+
+###
+# A volume container to hold source
+#
+# Using a conmtainer to hold source, even if it just locally binded source, is
+# a good idea, because it replicates what a production service would do.  It would
+# have source copied/exported/retrieved in, and make it available in the same way
+#
+source:
+  Type: volume
+
+  Config:
+    Image: jamesnesbitt/wunder-base # RUn from a standard base image
+  Host:
+    Binds:
+      - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+
+###
+# Database service
+#
+# This container is a base DB image with no existing DB, nor access.  Consider 
+# using a local build, to extend a base DB image, adding in a db, adding a user
+# and setting exactly what access credentials that you want
+#
+db:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+
+###
+# FPM service
+#
+# This node implements a scaling number of PHP7 FPM services from the same
+# image, running concurrently.
+#
+# Each instance will connect to the same single DB container.
+#
+fpm:
+  Type: service
+
+  Instances: scaled 3 9
+
+  Config:
+    Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+
+###
+# WWW service
+#
+# A scaling nginx node, that offers multiple instances of the same
+# image running concurrently.
+#
+# Each instance expects to have a matching FPM instance to link to
+# and will try to link to the instance with the matching instance id
+#
+# @note instance IDs are integer values
+# @note the container hostname will include the instance
+#
+www:
+  Type: service
+
+  Instances: scaled 3 9
+
+  Config:
+    Image: jamesnesbitt/wunder-nginx  # Recent nginx build using nginx provided centos repo
+    Hostname: "%PROJECT_%INSTANCE" # Tokens derived from the project and instance id
+    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+    Env:
+      - "DNSDOCK_ALIAS=%INSTANCE.%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+    ExposedPorts:
+      80/tcp: {}
+
+  Host:
+    Links:
+      - fpm:fpm.app # make the fpm service available as fpm.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+    PortBindings:
+      80/tcp:
+        - HostPort: "808%INSTANCE" # Port 808X applies to all Host IPs
+
+
+- Type: File
+  Path: app/README.md
+  Contents: |
+    # DEMO lamp
+
+    ## /app/source
+
+      Project source-code and assets path
+
+- Type: File
+  Path: app/source/index.php
+  Contents: |
+    <?php
+    /**
+     * Put your PHP source code here
+     *
+     * Not that in this demo project, only this folder gets mapped into
+     * the source container, so relative includes that point above will
+     * fail.  You can change the source node bind as needed.
+     */
+
+    phpinfo();

--- a/templates/demo/lamp_scaling/.coach/conf.yml
+++ b/templates/demo/lamp_scaling/.coach/conf.yml
@@ -1,0 +1,34 @@
+# Coach project conf
+#
+# Configurations for the coach project
+#
+# Project: project name, used to create container names
+# Author: used for docker commits & pushes.
+#   @note this needs to be valid for container names/images
+#     so it can contain alpha-numeric & "_"
+#
+# Tokens: a string map for string substitutions elsewhere
+#    by using the format %{key} in files loaded after this
+#    one
+#
+# Paths: a string map of paths that you can use for 
+#    things like docker builds and mounts.  Paths can be 
+#    absolute or relative to the project root.
+#    Note that you can override the following paths:
+#      - usertemplates : path to users init templates
+#      - usersecrets : path to user secrets
+#      - projectsecrets : path to project secrets
+#      - build : path to builds
+#    Paths are also made available as tokens using the
+#    format PATH_{UPPERCASEKEY}
+#
+
+# Project name
+Project: lampscaler
+
+Author: me
+
+# Custom Tokens
+Tokens:
+  # Set a container domain, which containers can pull in as ENV or box domains
+  CONTAINER_DOMAIN: demo.coach

--- a/templates/demo/lamp_scaling/.coach/nodes.yml
+++ b/templates/demo/lamp_scaling/.coach/nodes.yml
@@ -1,0 +1,101 @@
+###
+# Project nodes
+#
+# A string map of node configurations, each entry is a node, which 
+# corresponds to a set of containers based on a single image.  the
+# nodes have different types, an different purposes:
+#
+# Instances
+#
+# Note that while the source and db nodes will have single containers,
+# the www and fpm nodes will run somewhere between 3 and 9 containers
+# The www and fpm containers will try to correspond their links, but
+# all fpm containers will connect to the same DB and source containers
+#
+###
+
+###
+# A volume container to hold source
+#
+# Using a conmtainer to hold source, even if it just locally binded source, is
+# a good idea, because it replicates what a production service would do.  It would
+# have source copied/exported/retrieved in, and make it available in the same way
+#
+source:
+  Type: volume
+
+  Config:
+    Image: jamesnesbitt/wunder-base # RUn from a standard base image
+  Host:
+    Binds:
+      - "app/source:/app/www/active" # map the local source folder, into where the nginx/fpm expect the web root
+
+###
+# Database service
+#
+# This container is a base DB image with no existing DB, nor access.  Consider 
+# using a local build, to extend a base DB image, adding in a db, adding a user
+# and setting exactly what access credentials that you want
+#
+db:
+  Type: service
+
+  Config:
+    Image: jamesnesbitt/wunder-mariadb  # this base db image has no running db, user, access yet
+
+###
+# FPM service
+#
+# This node implements a scaling number of PHP7 FPM services from the same
+# image, running concurrently.
+#
+# Each instance will connect to the same single DB container.
+#
+fpm:
+  Type: service
+
+  Instances: scaled 3 9
+
+  Config:
+    Image: jamesnesbitt/wunder-php7fpm     # The FPM delivers the latest PHP7
+
+  Host:
+    Links:
+      - db:db.app # make the db container available as db.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+
+###
+# WWW service
+#
+# A scaling nginx node, that offers multiple instances of the same
+# image running concurrently.
+#
+# Each instance expects to have a matching FPM instance to link to
+# and will try to link to the instance with the matching instance id
+#
+# @note instance IDs are integer values
+# @note the container hostname will include the instance
+#
+www:
+  Type: service
+
+  Instances: scaled 3 9
+
+  Config:
+    Image: jamesnesbitt/wunder-nginx  # Recent nginx build using nginx provided centos repo
+    Hostname: "%PROJECT_%INSTANCE" # Tokens derived from the project and instance id
+    Domainname: "%CONTAINER_DOMAIN" # A token explicityl defined in conf,yml
+    Env:
+      - "DNSDOCK_ALIAS=%INSTANCE.%PROJECT.%CONTAINER_DOMAIN" # an optional ENV var to set, that works with DNSDOCK if you are using it.
+    ExposedPorts:
+      80/tcp: {}
+
+  Host:
+    Links:
+      - fpm:fpm.app # make the fpm service available as fpm.app
+    VolumesFrom:
+      - source  # map in all volumes from the source container
+    PortBindings:
+      80/tcp:
+        - HostPort: "808%INSTANCE" # Port 808X applies to all Host IPs

--- a/templates/demo/lamp_scaling/README.md
+++ b/templates/demo/lamp_scaling/README.md
@@ -1,0 +1,93 @@
+# COACH DEMO: Scaling LAMP
+
+This coach demo provides a scaling LAMP stack:
+
+- a single DB service using jamesnesbitt/wunder-mariadb
+
+- a scaling set of nginx/fpm pairs, starting at 3
+  but scaling up to 9 instances.
+
+  @these come in pairs to allow scaling http access, but
+    DNS should work if you do some local magic.
+
+To incorporate source, the source code from /app/source
+is mapped into a "source" container, which is used in
+the nginx and fpm containers.
+
+The Database is un-initialized, but an optional init
+build for a db has been included, and you can switch to
+it by removing the db node, and uncommenting the custom
+db node.
+
+All of the suggested images in this project are based on
+the wunder-base concept, which is used to provide a commong
+/app project folder, and similar users/OS, to keep access
+privileges working better.
+The builds are all CentOS7, EPEL and often REMI based builds.
+
+# Getting Started:
+
+  You already did this:
+
+    #/> coach init demo lamp_scaling
+
+  Now just do this:
+
+    $/> coach up
+
+  This should:
+
+    - download some images
+    - build any local images that were defined
+    - create a source container which will map ./app/source to /app/www/active
+
+    - start some nginx containers, and  some fpm containers and a single db container
+
+  You should then have
+
+    - http access to all nginx services by directly pointing to the container
+
+# Day to day use
+
+## starting and stopping
+
+    $/> coach stop
+    $/> coach start
+
+## starting and stopping more instances
+
+  Use the scale operation to start additional instances:
+
+    $/> coach scale up
+
+  And the same operation to scale down
+
+    $/> coach scale down
+
+## starting a specific container
+
+  - start a specific node
+
+    $/> coach @www start
+
+  - start all service nodes
+
+    $/> coach %service start
+
+## rebuild any containers
+
+  1. stop any running containers
+
+    $/> coach stop
+
+  2. remove and created containers
+
+    $/> coach remove
+
+  3. recreate and containers
+
+    $/> coach create
+
+  4. start the new containers
+
+    $/> coach start

--- a/templates/demo/lamp_scaling/app/README.md
+++ b/templates/demo/lamp_scaling/app/README.md
@@ -1,0 +1,5 @@
+# DEMO
+
+## /app/source
+
+  Project source-code and assets path

--- a/templates/demo/lamp_scaling/app/source/index.php
+++ b/templates/demo/lamp_scaling/app/source/index.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Put your PHP source code here
+ *
+ * Not that in this demo project, only this folder gets mapped into
+ * the source container, so relative includes that point above will
+ * fail.  You can change the source node bind as needed.
+ */
+
+phpinfo();


### PR DESCRIPTION
This patch adds in the templates for various demo inits.
- standard LAMP stack
- a LAMP stack that runs php56, php7 and HHVM concurrently
- a monolothic LAMP stack
- a LAMP stack with scaling nginx/php-fpm services

More templates to come.
