### PR TITLE
merge remoteyaml and yaml operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The syntax for using your own local yaml file:
     
 or remote yaml
 
-    $/> coach init remoteyaml https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/drupal8/.coach/coachinit.yml
+    $/> coach init yaml https://raw.githubusercontent.com/james-nesbitt/coach/master/templates/demo/drupal8/.coach/coachinit.yml
 
 Take a look at the existing demos for the syntax:
 


### PR DESCRIPTION
The two init cases are identical except that one retrieve a byte stream from http, and the other from a local file.  It makes sense just to merge the two.
