### PR TITLE
restore some legact token behaviour to add default tokens

### DIFF
--- a/conf/flag.go
+++ b/conf/flag.go
@@ -1,19 +1,49 @@
 package conf
 
+import (
+	"os"
+	"strings"
+
+	"github.com/james-nesbitt/coach/log"
+)
+
 const (
 	COACH_PROJECT_FLAG_DEFAULT_UsePathsAsTokens        = true
 	COACH_PROJECT_FLAG_DEFAULT_UseEnvVariablesAsTokens = false
 )
 
-func MakeProjectFlags() ProjectFlags {
-	return ProjectFlags{
+func MakeProjectFlags() Flags {
+	return Flags{
 		UsePathsAsTokens:        COACH_PROJECT_FLAG_DEFAULT_UsePathsAsTokens,
 		UseEnvVariablesAsTokens: COACH_PROJECT_FLAG_DEFAULT_UseEnvVariablesAsTokens,
 	}
 }
 
 // ProjectFlags are Configuration flags for the project settings
-type ProjectFlags struct {
+type Flags struct {
 	UsePathsAsTokens        bool // Should all of the paths be available as tokens
 	UseEnvVariablesAsTokens bool // Should the running user ENV variables be available as tokens
+}
+
+func (project *Project) ProcessFlags(logger log.Log) {
+
+	// add any paths as tokens if told to do so
+	if project.Flags.UsePathsAsTokens {
+		for _, pathKey := range project.Paths.PathOrder() {
+			path, _ := project.Paths.Path(pathKey)
+			project.Tokens.SetToken("PATH_"+strings.ToUpper(pathKey), path)
+		}
+	}
+
+	// add all environment variables for the user to the token list
+	if project.Flags.UseEnvVariablesAsTokens {
+		for _, env := range os.Environ() {
+			envsplit := strings.SplitN(env, "=", 2)
+			if len(envsplit) == 1 {
+				envsplit = append(envsplit, "")
+			}
+			project.Tokens[envsplit[0]] = envsplit[1]
+		}
+	}
+
 }

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -30,6 +30,16 @@ func (paths *Paths) Path(key string) (path string, ok bool) {
 	return
 }
 
+// return an ordered list of paths
+// (really the order doesn't matter, but this fits a pattern that we use a lot in coach)
+func (paths *Paths) PathOrder() []string {
+	pathOrder := []string{}
+	for path, _ := range paths.Paths {
+		pathOrder = append(pathOrder, path)
+	}
+	return pathOrder
+}
+
 // Add a new Path to the Paths
 func (paths *Paths) SetPath(key string, keyPath string, overwrite bool) bool {
 	if _, ok := paths.Paths[key]; overwrite || !ok {

--- a/conf/project.go
+++ b/conf/project.go
@@ -9,9 +9,9 @@ import (
 // MakeCoachProject Project constructor for building a project based on a project path
 func MakeCoachProject(logger log.Log, workingDir string) (project *Project) {
 	project = &Project{
-		Paths:        MakePaths(),        // empty typesafe paths object
-		Tokens:       MakeTokens(),       // empty tokens object
-		ProjectFlags: MakeProjectFlags(), // empty flags object
+		Paths:  MakePaths(),        // empty typesafe paths object
+		Tokens: MakeTokens(),       // empty tokens object
+		Flags:  MakeProjectFlags(), // empty flags object
 	}
 
 	/**
@@ -36,7 +36,14 @@ func MakeCoachProject(logger log.Log, workingDir string) (project *Project) {
 	 */
 	project.from_SecretsYaml(logger.MakeChild("secrets"))
 
-	return
+	/**
+	 * 4. Run the project prepare, which will validate the configuration
+	 */
+	if !project.Prepare(logger) {
+		logger.Warning("Coach configuration processing failed")
+	}
+
+	return project
 }
 
 // Project settings handler for coach, used to centralize and validate settings for a project
@@ -48,7 +55,23 @@ type Project struct {
 
 	Tokens
 
-	ProjectFlags
+	Flags
+}
+
+func (project *Project) Prepare(logger log.Log) bool {
+
+	/**
+	 * Add some default tokens
+	 */
+	project.Tokens["PROJECT"] = project.Name
+	project.Tokens["AUTHOR"] = project.Author
+
+	/**
+	 * Process configuration based on flags
+	 */
+	project.ProcessFlags(logger)
+
+	return true
 }
 
 // Is this project configured enough to run coach

--- a/conf/project_fromyaml.go
+++ b/conf/project_fromyaml.go
@@ -65,6 +65,7 @@ type conf_Yaml struct {
 // Make a Yaml Conf apply configuration to a project object
 func (conf *conf_Yaml) configureProject(logger log.Log, project *Project) bool {
 	// set a project name
+
 	if conf.Project != "" {
 		project.Name = conf.Project
 	}
@@ -95,7 +96,7 @@ func (conf *conf_Yaml) configureProject(logger log.Log, project *Project) bool {
 		}
 	}
 
-	logger.Debug(log.VERBOSITY_DEBUG_LOTS, "Configured project from YAML conf")
+	logger.Debug(log.VERBOSITY_DEBUG_LOTS, "Configured project from YAML conf", project)
 	return true
 }
 


### PR DESCRIPTION
This patch restores some of the 1.x default token behaviour:
- some default conf settings are used as tokens : PROJECT and AUTHOR
- ENV variables can be used as tokens if a flag is set in the conf.yml file
- paths can be used as tokens if a flag is set in the conf.yml file
