### PR TITLE
some standardization cleanup in libs

### DIFF
--- a/libs/node.go
+++ b/libs/node.go
@@ -90,6 +90,8 @@ func (node *BaseNode) Prepare(logger log.Log, nodes *Nodes) (success bool) {
 
 func (node *BaseNode) Can(action string) bool {
 	switch action {
+	case "run":
+		return false
 	default:
 		return node.client.Can(action)
 	}

--- a/libs/node_build.go
+++ b/libs/node_build.go
@@ -1,8 +1,6 @@
 package libs
 
 import (
-	"strings"
-
 	"github.com/james-nesbitt/coach/conf"
 	"github.com/james-nesbitt/coach/log"
 )
@@ -55,7 +53,7 @@ func (node *BuildNode) defaultInstances(logger log.Log, client Client, instances
 
 // Build Nodes can only build
 func (node *BuildNode) Can(action string) bool {
-	switch strings.ToLower(action) {
+	switch action {
 	case "destroy":
 		fallthrough
 	case "clean":


### PR DESCRIPTION
This patch converts one of the node Can() checks to no longer ToLower and action name, similar to all of the other Node Can() methods.
