### PR TITLE
New Init string replace method

### DIFF
--- a/initialize/init.go
+++ b/initialize/init.go
@@ -51,6 +51,15 @@ func (tasks *InitTasks) AddFileCopy(path string, source string) {
 		source: source,
 	}))
 }
+func (tasks *InitTasks) AddFileStringReplace(path string, oldString string, newString string, replaceCount int) {
+	tasks.AddTask(InitTask(&InitTaskFileStringReplace{
+		root:   tasks.root,
+		path:   path,
+		oldString: oldString,
+		newString: newString,
+		replaceCount: replaceCount,
+	}))
+}
 func (tasks *InitTasks) AddGitClone(path string, url string) {
 	tasks.AddTask(InitTask(&InitTaskGitClone{
 		root: tasks.root,

--- a/initialize/yaml.go
+++ b/initialize/yaml.go
@@ -93,6 +93,12 @@ func (tasks *InitTasks) AddTasksFromYaml(logger log.Log, yamlSource []byte) erro
 			if err := json.Unmarshal(json_task, &task); err == nil {
 				taskAdder = TaskAdder(&task)
 			}
+		case "FileStringReplace":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_FileStringReplace
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
 		case "GitClone":
 			json_task, _ := json.Marshal(task_struct)
 			var task InitTaskYaml_GitClone
@@ -159,6 +165,17 @@ type InitTaskYaml_FileCopy struct {
 
 func (task *InitTaskYaml_FileCopy) AddTask(tasks *InitTasks) {
 	tasks.AddFileCopy(task.Path, task.Source)
+}
+
+type InitTaskYaml_FileStringReplace struct {
+	Path   string `json:"Path" yaml:"Path"`
+	OldString string `json:"Old" yaml:"Source"`
+	NewString string `json:"New" yaml:"Source"`
+	ReplaceCount int `json:"Limit" yaml:"Source"`
+}
+
+func (task *InitTaskYaml_FileStringReplace) AddTask(tasks *InitTasks) {
+	tasks.AddFileStringReplace(task.Path, task.OldString, task.NewString, task.ReplaceCount)
 }
 
 type InitTaskYaml_GitClone struct {


### PR DESCRIPTION
This patch adds an init task to perform a string replacement on a file.

This is usefull as it means that files that are copied, or checked out can be easlily modified, instead of replacing with custom contents.  This can reduce the size of init instruction sets.
