### PR TITLE
added pull type nodes

### DIFF
--- a/libs/node_pull.go
+++ b/libs/node_pull.go
@@ -1,0 +1,66 @@
+package libs
+
+import (
+	"github.com/james-nesbitt/coach/conf"
+	"github.com/james-nesbitt/coach/log"
+)
+
+type PullNodeSettings struct {
+	Type string `json:"Type,omitempty" yaml:"Type,omitempty"`
+}
+
+type PullNode struct {
+	BaseNode
+	Settings PullNodeSettings
+}
+
+// Declare node type
+func (node *PullNode) Type() string {
+	return "pull"
+}
+func (node *PullNode) Init(logger log.Log, name string, project *conf.Project, client Client, instancesSettings InstancesSettings) bool {
+	node.BaseNode.Init(logger, name, project, client, instancesSettings)
+
+	settingsInterface := instancesSettings.Settings()
+	switch settingsInterface.(type) {
+	case FixedInstancesSettings:
+		logger.Warning("Pull node cannot be configured to use fixed instances.  Using null instance instead.")
+		node.defaultInstances(logger, client, instancesSettings)
+	case ScaledInstancesSettings:
+		logger.Warning("Pull node cannot be configured to use scaled instances.  Using null instance instead.")
+		node.defaultInstances(logger, client, instancesSettings)
+	case SingleInstancesSettings:
+		logger.Warning("Pull node cannot be configured to use single instances.  Using null instance instead.")
+		node.defaultInstances(logger, client, instancesSettings)
+	case TemporaryInstancesSettings:
+		logger.Warning("Pull node cannot be configured to use disposable instances.  Using null instance instead.")
+		node.defaultInstances(logger, client, instancesSettings)
+	default:
+		node.defaultInstances(logger, client, instancesSettings)
+	}
+
+	node.instances.Init(logger, node.MachineName(), client, instancesSettings)
+
+	logger.Debug(log.VERBOSITY_DEBUG_STAAAP, "Built new node:", node.client)
+	return true
+}
+
+// a central instances configuration method, that will create the default single settings
+// @note we use this mainly because you cannot fallthrough on a .(type) switch statement
+func (node *PullNode) defaultInstances(logger log.Log, client Client, instancesSettings InstancesSettings) {
+	node.instances = Instances(&NullInstances{})
+}
+
+// Pull Nodes can only Pull
+func (node *PullNode) Can(action string) bool {
+	switch action {
+	case "destroy":
+		fallthrough
+	case "clean":
+		fallthrough
+	case "pull":
+		return true
+	default:
+		return false
+	}
+}

--- a/libs/nodes_fromyaml.go
+++ b/libs/nodes_fromyaml.go
@@ -87,6 +87,8 @@ NodesListLoop:
 			node = Node(&BuildNode{})
 		case "volume":
 			node = Node(&VolumeNode{})
+		case "pull":
+			node = Node(&PullNode{})
 		case "service":
 			node = Node(&ServiceNode{})
 		default:


### PR DESCRIPTION
This patch adds a new node type for "Pull type" nodes, which are similar to build nodes, but only allow image pulls.  The nodes yaml syntax handling has been adapted to allow Type: pull.

This is in response to issue: https://github.com/james-nesbitt/coach/issues/81

The pull node type is meant to allow a node to be defined only to allow a common base image to be pulled.  This can have a performance or logistical value, but really is present to allow simpler builds from common base nodes.
