### PR TITLE
add manual dependencies to base node

### DIFF
--- a/libs/nodes_fromyaml.go
+++ b/libs/nodes_fromyaml.go
@@ -111,6 +111,11 @@ NodesListLoop:
 
 			// run the node initializaer with the collected obkjects
 			if node.Init(nodeLogger, name, project, client, instancesSettings) {
+				// add any manual dependencies specified
+				for _, dependency := range node_yaml.Requires {
+					node.AddDependency(dependency)
+				}
+
 				nodeLogger.Debug(log.VERBOSITY_DEBUG_LOTS, "Adding node to nodes list:", name, node)
 				nodes.SetNode(name, node, true)
 			}
@@ -148,7 +153,7 @@ type node_yaml_v2 struct {
 
 	Docker FSouza_ClientSettings `yaml:"Docker,omitempty"`
 
-	Requires map[string][]string `yaml:"Requires,omitempty"`
+	Requires []string `yaml:"Requires,omitempty"`
 }
 
 func (node *node_yaml_v2) Type() (string, bool) {


### PR DESCRIPTION
This patch adds a manual dependency concept to the node interface, and an implementation in the base node class.

The nodes yaml handler now properly passes the Requires: elements into manual dependencies.

This is in response to issue: https://github.com/james-nesbitt/coach/issues/80
