### PR TITLE
added new status operation

### DIFF
--- a/operation/operation.go
+++ b/operation/operation.go
@@ -20,6 +20,8 @@ func MakeOperation(logger log.Log, project *conf.Project, name string, flags []s
 	switch name {
 	case "info":
 		operation = Operation(&InfoOperation{log: opLogger, targets: targets})
+	case "status":
+		operation = Operation(&StatusOperation{log: opLogger, targets: targets})
 
 	case "pull":
 		operation = Operation(&PullOperation{log: opLogger, targets: targets})
@@ -133,6 +135,7 @@ func ListOperations() []string {
 		"create",
 		"remove",
 		"start",
+		"status",
 		"stop",
 		"attach",
 		"pause",
@@ -168,6 +171,10 @@ func (operation *UnknownOperation) Help(flags []string) {
 	return
 }
 func (operation *UnknownOperation) Run(logger log.Log) bool {
-	logger.Error("Unknown operation: " + operation.id)
+	if operation.id==DEFAULT_OPERATION {
+		logger.Error("No operation specified")
+	} else {
+		logger.Error("Unknown operation: " + operation.id)			
+	}
 	return false
 }

--- a/operation/operation_status.go
+++ b/operation/operation_status.go
@@ -1,0 +1,106 @@
+package operation
+
+import (
+	"strings"
+	"strconv"
+
+	"github.com/james-nesbitt/coach/libs"
+	"github.com/james-nesbitt/coach/log"
+)
+
+type StatusOperation struct {
+	log     log.Log
+	targets *libs.Targets
+}
+
+func (operation *StatusOperation) Id() string {
+	return "Status"
+}
+func (operation *StatusOperation) Flags(flags []string) bool {
+	return true
+}
+func (operation *StatusOperation) Help(flags []string) {
+	operation.log.Message(`Operation: Status
+
+Coach will attempt to provide project Status by investigating target images and containers.
+
+SYNTAX:
+	$/> coach {targets} Status
+
+	{targets} what target nodes the operation should process ($/> coach help targets)
+
+`)
+}
+func (operation *StatusOperation) Run(logger log.Log) bool {
+	logger.Message("RUNNING Status OPERATION")
+
+	logger.Debug(log.VERBOSITY_DEBUG, "Run:Targets", operation.targets.TargetOrder())
+	for _, targetID := range operation.targets.TargetOrder() {
+		target, targetExists := operation.targets.Target(targetID)
+		node, hasNode := target.Node()
+		instances, hasInstances := target.Instances()
+
+		if !targetExists {
+			// this is strange
+			logger.Warning("Internal target error, was told to use a target that doesn't exist")
+			continue
+		}
+
+		nodeLogger := logger.MakeChild(targetID)
+		status := []string{}
+
+
+		if hasNode {
+			status = append(status, operation.NodeStatus(nodeLogger, node)...)
+		} else {
+			status = append(status, "No node for target")
+		}
+		if hasInstances {
+			status = append(status, operation.InstancesStatus(nodeLogger, instances)...)
+		} else {
+			status = append(status, "No instances for target")
+		}
+
+		nodeLogger.Message( "["+strings.Join(status, "][")+"]" )
+	}
+
+	return true
+}
+
+
+func (operation *StatusOperation) NodeStatus(logger log.Log, node libs.Node) []string {
+	status := []string{}
+
+	if node.Client().HasImage() {
+		status = append(status, "Image:good")
+	} else {
+		status = append(status, "Image:No Image")
+	}
+
+	return status
+}
+
+func (operation *StatusOperation) InstancesStatus(logger log.Log, instances libs.FilterableInstances) []string {
+	status := []string{}
+
+	allCount := 0
+	runningCount := 0
+	for _, id := range instances.InstancesOrder() {
+		instance, _ := instances.Instance(id)
+		instanceClient := instance.Client()
+		if instanceClient.IsRunning() {
+			allCount++
+			runningCount++
+		} else if instanceClient.HasContainer() {
+			allCount++
+		}
+	}
+
+	if allCount>0 {
+		status = append(status, "Containers:"+strconv.Itoa(runningCount)+"/"+strconv.Itoa(allCount))
+	} else {
+		status = append(status, "Containers:NONE")
+	}
+
+	return status
+}


### PR DESCRIPTION
The Info operation doesn't produce easy to read,  or good machine-readable output.  This patch adds a new more concise status operation, that outputs only 1 row per node.

It's initial implementation makes it much easier to read, although it doesn't give very comprehensive output.  I will upgrade it in the future to handler better the nuances of different node/instances types, but for now if gives some decent details.
