### PR TITLE
Initial environment code

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -15,6 +15,7 @@ var (
 	mainTargets    []string
 	globalFlags    map[string]string
 	operationFlags []string
+	environment   string
 
 	logger  log.Log       // Logger interface for tracking messages
 	project *conf.Project // project configuration
@@ -22,7 +23,7 @@ var (
 
 func init() {
 
-	operationName, mainTargets, globalFlags, operationFlags = parseGlobalFlags(os.Args)
+	operationName, mainTargets, globalFlags, operationFlags, environment = parseGlobalFlags(os.Args)
 
 	// verbosity
 	var verbosity int = log.VERBOSITY_MESSAGE
@@ -49,7 +50,7 @@ func init() {
 	workingDir, _ := os.Getwd()
 	logger.Debug(log.VERBOSITY_DEBUG, "Working Directory", workingDir)
 
-	project = conf.MakeCoachProject(logger.MakeChild("conf"), workingDir)
+	project = conf.MakeCoachProject(logger.MakeChild("conf"), workingDir, environment)
 	logger.Debug(log.VERBOSITY_DEBUG, "Project configuration", *project)
 
 	logger.Debug(log.VERBOSITY_DEBUG, "Finished initialization", nil)
@@ -57,7 +58,7 @@ func init() {
 
 func main() {
 
-	if !(operationName == "init" || project.IsValid(logger.MakeChild("Sanity Check"))) {
+	if !(operationName == "init" || operationName == "help" || project.IsValid(logger.MakeChild("Sanity Check"))) {
 		logger.Error("Coach project configuration is not processable.  Execution halted. [" + operationName + "]")
 		return
 	}

--- a/coach-tool/cli.go
+++ b/coach-tool/cli.go
@@ -11,6 +11,7 @@ import (
 var (
 	globalFlags    map[string]string
 	operationFlags []string
+	environment    string
 
 	logger  log.Log       // Logger interface for tracking messages
 	project *conf.Project // project configuration
@@ -18,7 +19,7 @@ var (
 
 func init() {
 
-	globalFlags, operationFlags = parseGlobalFlags(os.Args)
+	globalFlags, operationFlags, environment = parseGlobalFlags(os.Args)
 
 	// verbosity
 	var verbosity int = log.VERBOSITY_MESSAGE
@@ -45,7 +46,7 @@ func init() {
 	workingDir, _ := os.Getwd()
 	logger.Debug(log.VERBOSITY_DEBUG, "Working Directory", workingDir)
 
-	project = conf.MakeCoachProject(logger.MakeChild("conf"), workingDir)
+	project = conf.MakeCoachProject(logger.MakeChild("conf"), workingDir, environment)
 	logger.Debug(log.VERBOSITY_DEBUG, "Project configuration", *project)
 
 	logger.Debug(log.VERBOSITY_DEBUG, "Finished initialization", nil)

--- a/coach-tool/flags.go
+++ b/coach-tool/flags.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"github.com/james-nesbitt/coach/conf"
+)
+
 /**
  * Parse command flags to configure the operation
  *
@@ -8,9 +12,11 @@ package main
  * 3. OPERATION ARGUMENTS : anything left
  *
  */
-func parseGlobalFlags(flags []string) (globalFlags map[string]string, operationFlags []string) {
+func parseGlobalFlags(flags []string) (globalFlags map[string]string, operationFlags []string, environment string) {
 
 	globalFlags = map[string]string{} // start of with no flags
+
+	environment = conf.COACH_CONF_ENVIRONMENTS_DEFAULT
 
 	global := true // start of assuming everything is a global arg
 	for index := 1; index < len(flags); index++ {
@@ -35,7 +41,18 @@ func parseGlobalFlags(flags []string) (globalFlags map[string]string, operationF
 			globalFlags["verbosity"] = "staaap"
 
 		default:
-			global = false
+
+			/**
+			* The first flags that we don't recognize as global, fall into three cases:
+			*  :{flag} : indicates an environment
+			 */
+
+			switch arg[0:1] {
+			case ":": // environment
+				environment = arg[1:]
+			default:
+				global = false
+			}
 
 		}
 

--- a/conf/environment.go
+++ b/conf/environment.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"strconv"
+	"path"
 
 	"github.com/james-nesbitt/coach/log"
 )
@@ -20,6 +21,8 @@ func (project *Project) from_EnvironmentsPath(logger log.Log) {
 	for _, yamlEnvironmentPath := range project.Paths.GetConfSubPaths(COACH_CONF_ENVIRONMENTS_SUBPATH) {
 		logger.Debug(log.VERBOSITY_DEBUG_STAAAP, "Looking for Environment subpath: "+yamlEnvironmentPath)
 
+		yamlEnvironmentPath = path.Join(yamlEnvironmentPath, project.Environment)
+
 		if project.CheckFileExists(yamlEnvironmentPath) {
 
 			logger.Debug(log.VERBOSITY_DEBUG, "ADDING Environment subpath: "+yamlEnvironmentPath)
@@ -28,7 +31,7 @@ func (project *Project) from_EnvironmentsPath(logger log.Log) {
 			envid := COACH_CONF_ENVIRONMENTS_SUBPATH+"-"+strconv.Itoa(environmentIncrement)
 
 			project.SetPath(envid, yamlEnvironmentPath, true)
-			project.setConfPath("project-coach")
+			project.setConfPath(envid)
 
 		}
 	}

--- a/conf/environment.go
+++ b/conf/environment.go
@@ -1,0 +1,35 @@
+package conf
+
+import (
+	"strconv"
+
+	"github.com/james-nesbitt/coach/log"
+)
+
+const (
+	COACH_CONF_ENVIRONMENTS_DEFAULT = "default"
+	COACH_CONF_ENVIRONMENTS_SUBPATH = "environments"
+)
+
+var (
+	environmentIncrement = 0
+)
+
+// Look for project configurations inside the environment conf paths
+func (project *Project) from_EnvironmentsPath(logger log.Log) {
+	for _, yamlEnvironmentPath := range project.Paths.GetConfSubPaths(COACH_CONF_ENVIRONMENTS_SUBPATH) {
+		logger.Debug(log.VERBOSITY_DEBUG_STAAAP, "Looking for Environment subpath: "+yamlEnvironmentPath)
+
+		if project.CheckFileExists(yamlEnvironmentPath) {
+
+			logger.Debug(log.VERBOSITY_DEBUG, "ADDING Environment subpath: "+yamlEnvironmentPath)
+
+			environmentIncrement++
+			envid := COACH_CONF_ENVIRONMENTS_SUBPATH+"-"+strconv.Itoa(environmentIncrement)
+
+			project.SetPath(envid, yamlEnvironmentPath, true)
+			project.setConfPath("project-coach")
+
+		}
+	}
+}

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -82,5 +82,5 @@ func (paths *Paths) GetConfSubPaths(subPath string) []string {
 // @NOTE it's best not to check if a path exists.
 func (paths *Paths) CheckFileExists(filePath string) bool {
 	_, err := os.Stat(filePath)
-	return err == nil
+	return os.IsNotExist(err)
 }

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -82,5 +82,5 @@ func (paths *Paths) GetConfSubPaths(subPath string) []string {
 // @NOTE it's best not to check if a path exists.
 func (paths *Paths) CheckFileExists(filePath string) bool {
 	_, err := os.Stat(filePath)
-	return os.IsNotExist(err)
+	return !os.IsNotExist(err)
 }

--- a/conf/project.go
+++ b/conf/project.go
@@ -7,8 +7,9 @@ import (
 )
 
 // MakeCoachProject Project constructor for building a project based on a project path
-func MakeCoachProject(logger log.Log, workingDir string) (project *Project) {
+func MakeCoachProject(logger log.Log, workingDir string, environment string) (project *Project) {
 	project = &Project{
+		Environment: environment,   // base on the default environment
 		Paths:  MakePaths(),        // empty typesafe paths object
 		Tokens: MakeTokens(),       // empty tokens object
 		Flags:  MakeProjectFlags(), // empty flags object
@@ -34,10 +35,15 @@ func MakeCoachProject(logger log.Log, workingDir string) (project *Project) {
 	/**
 	 * 3. Try to load secrets from configuration paths
 	 */
+	project.from_EnvironmentsPath(logger.MakeChild("environment"))
+
+	/**
+	 * 4. Try to load secrets from configuration paths
+	 */
 	project.from_SecretsYaml(logger.MakeChild("secrets"))
 
 	/**
-	 * 4. Run the project prepare, which will validate the configuration
+	 * 5. Run the project prepare, which will validate the configuration
 	 */
 	if !project.Prepare(logger) {
 		logger.Warning("Coach configuration processing failed")
@@ -50,6 +56,8 @@ func MakeCoachProject(logger log.Log, workingDir string) (project *Project) {
 type Project struct {
 	Name   string
 	Author string
+
+	Environment string
 
 	Paths
 

--- a/conf/project_fromyaml.go
+++ b/conf/project_fromyaml.go
@@ -55,6 +55,8 @@ type conf_Yaml struct {
 	Project string `yaml:"Project,omitempty"`
 	Author  string `yaml:"Author,omitempty"`
 
+	Environment string `yaml:"Environment,omitempty"`
+
 	Paths map[string]string `yaml:"Paths,omitempty"`
 
 	Tokens map[string]string `yaml:"Tokens,omitempty"`
@@ -72,6 +74,11 @@ func (conf *conf_Yaml) configureProject(logger log.Log, project *Project) bool {
 	// set a author name
 	if conf.Author != "" {
 		project.Author = conf.Author
+	}
+
+	// set an environment string
+	if conf.Environment != "" {
+		project.Environment = conf.Environment
 	}
 
 	// set any paths

--- a/flags.go
+++ b/flags.go
@@ -50,6 +50,7 @@ func parseGlobalFlags(flags []string) (operationName string, targetIdentifiers [
 
 			/**
 			* The first flags that we don't recognize as global, fall into three cases:
+			*  :{flag} : indicates an environment
 			*  @{flag} : indicates a node target, can be repeated
 			*  %{flag} : indicates a node type target, can be repeated
 			*  -{flag} : indicates the end of global flag targeting, and starts the collection of operationFlags

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/james-nesbitt/coach/conf"
 	"github.com/james-nesbitt/coach/operation"
 )
 
@@ -12,11 +13,13 @@ import (
  * 3. OPERATION ARGUMENTS : anything left
  *
  */
-func parseGlobalFlags(flags []string) (operationName string, targetIdentifiers []string, globalFlags map[string]string, operationFlags []string) {
+func parseGlobalFlags(flags []string) (operationName string, targetIdentifiers []string, globalFlags map[string]string, operationFlags []string, environment string) {
 	operationName = operation.DEFAULT_OPERATION // default operation, to be interpreted later, if not set in this function
 
 	globalFlags = map[string]string{} // start of with no flags
 	targetIdentifiers = []string{}    //  ||
+
+	environment = conf.COACH_CONF_ENVIRONMENTS_DEFAULT
 
 	global := true // start of assuming everything is a global arg
 	for index := 1; index < len(flags); index++ {
@@ -54,6 +57,9 @@ func parseGlobalFlags(flags []string) (operationName string, targetIdentifiers [
 			 */
 
 			switch arg[0:1] {
+			case ":": // environment
+				environment = arg[1:]
+
 			case "@": // target
 				fallthrough
 			case "%": // type

--- a/help/help_fromyaml.go
+++ b/help/help_fromyaml.go
@@ -15,7 +15,6 @@ const (
 
 // Ummarshaller interface : pass incoming yaml into the topics
 func (help *Help) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	help.log.Debug(log.VERBOSITY_MESSAGE, "UNMARSHALL:", help.topics)
 	return unmarshal(&help.topics)
 }
 


### PR DESCRIPTION
This patch add a configuration "environment" variable, which can correspond to a configuration base kept in a sub-path of any other configuration base, of the form {conf-path}/environments/{environment}/

For example, you can define a "development" environment by creating:
  .coach/environments/development

Then if you use the development environment, this path is also considered a source of configurations including secrets and nodes.  In general, environment settings override any previously set configurations, but this is the base coach behaviour anyway, to allow a later conf to override a previous conf; all we are doing as adding a new possible path for source.

You can activate an environment by a command line marker ":{environment}" or by setting "Environment: {environment}" in a conf.yml file.

@TODO:
- this environment is checked after conf.yml files are read, meaning that no conf.yml is checked from the environment folders.  This could manually be done if needed.
