### PR TITLE
fix help operation if operations look similar

### DIFF
--- a/operation/operation_help.go
+++ b/operation/operation_help.go
@@ -109,7 +109,7 @@ func (operation *HelpOperation) Run(logger log.Log) bool {
 	} else {
 
 		for _, operationName := range ListOperations() {
-			if strings.HasPrefix(helpTopicName, operationName) {
+			if helpTopicName == operationName || strings.HasPrefix(helpTopicName, operationName+":") {
 				if helpOperations := MakeOperation(logger, operation.conf, operationName, operation.flags, &libs.Targets{}); len(helpOperations.operationsList) > 0 {
 					for _, helpOperation := range helpOperations.operationsList {
 						helpOperation.Help(append([]string{helpTopicName}, helpTopicFlags...))


### PR DESCRIPTION
I noticed that the help topic for init-generate fails.  It shows the init help topic.  I found a string identity logic error in the help topic identifier, and fixed it.
